### PR TITLE
chore: Use check for pdm lock.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,9 +42,9 @@ repos:
           - post-merge
         always_run: true
         pass_filenames: false
-      - id: pdm-lock
-        name: pdm-lock
-        entry: pdm lock
+      - id: pdm-lock-check
+        name: pdm-lock-check
+        entry: pdm lock --check
         language: python
         files: ^pyproject.toml$
         pass_filenames: false

--- a/template/.pre-commit-config.yaml.jinja
+++ b/template/.pre-commit-config.yaml.jinja
@@ -43,9 +43,9 @@ repos:
           - post-merge
         always_run: true
         pass_filenames: false
-      - id: pdm-lock
-        name: pdm-lock
-        entry: pdm lock
+      - id: pdm-lock-check
+        name: pdm-lock-check
+        entry: pdm lock --check
         language: python
         files: ^pyproject.toml$
         pass_filenames: false


### PR DESCRIPTION
`pdm lock` and `pdm lock --check` are almost not the same thing. `pdm lock --check` will just check against the lock file and `pdm lock` will resolve the dependencies again and lead to potential update.

<!-- readthedocs-preview ss-python start -->
----
📚 Documentation preview 📚: https://ss-python--268.org.readthedocs.build/en/268/

<!-- readthedocs-preview ss-python end -->