### PR TITLE
chore: Remove json related pre-commit hooks due to jsonc incompatibility.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,6 @@ repos:
     hooks:
       - id: check-added-large-files
       - id: check-docstring-first
-      - id: check-json
       - id: check-merge-conflict
         args:
           - '--assume-in-merge'
@@ -25,9 +24,6 @@ repos:
       - id: no-commit-to-branch
         stages:
           - pre-push
-      - id: pretty-format-json
-        args:
-          - '--autofix'
       - id: sort-simple-yaml
         files: .pre-commit-config.yaml
       - id: trailing-whitespace

--- a/template/.pre-commit-config.yaml.jinja
+++ b/template/.pre-commit-config.yaml.jinja
@@ -12,7 +12,6 @@ repos:
     hooks:
       - id: check-added-large-files
       - id: check-docstring-first
-      - id: check-json
       - id: check-merge-conflict
         args:
           - '--assume-in-merge'
@@ -26,9 +25,6 @@ repos:
       - id: no-commit-to-branch
         stages:
           - pre-push
-      - id: pretty-format-json
-        args:
-          - '--autofix'
       - id: sort-simple-yaml
         files: .pre-commit-config.yaml
       - id: trailing-whitespace


### PR DESCRIPTION
For Json/Jsonc lint/formatter/pre-commit, another issue is created to track.


<!-- readthedocs-preview ss-python start -->
----
📚 Documentation preview 📚: https://ss-python--278.org.readthedocs.build/en/278/

<!-- readthedocs-preview ss-python end -->