### PR TITLE
chore: Use bash as the default shell for the non-root user in devcontainer.

### DIFF
--- a/.devcontainer/prebuild/.devcontainer/Dockerfile
+++ b/.devcontainer/prebuild/.devcontainer/Dockerfile
@@ -30,7 +30,7 @@ ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
 RUN groupadd --gid $USER_GID $USERNAME \
-    && useradd --create-home --uid $USER_UID --gid $USER_GID $USERNAME \
+    && useradd --create-home --uid $USER_UID --gid $USER_GID $USERNAME -s /bin/bash \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME
 

--- a/template/.devcontainer/prebuild/.devcontainer/Dockerfile.jinja
+++ b/template/.devcontainer/prebuild/.devcontainer/Dockerfile.jinja
@@ -30,7 +30,7 @@ ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
 RUN groupadd --gid $USER_GID $USERNAME \
-    && useradd --create-home --uid $USER_UID --gid $USER_GID $USERNAME \
+    && useradd --create-home --uid $USER_UID --gid $USER_GID $USERNAME -s /bin/bash \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME
 


### PR DESCRIPTION
…ainer.

<!-- readthedocs-preview ss-python start -->
----
📚 Documentation preview 📚: https://ss-python--285.org.readthedocs.build/en/285/

<!-- readthedocs-preview ss-python end -->