### PR TITLE
doc: Remove command from generated release notes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ changelog:
 
 # Generate release notes from changelog.
 release-notes:
-	git-changelog --input $(CHANGELOG_PATH) --release-notes
+	@git-changelog --input $(CHANGELOG_PATH) --release-notes
 
 # Build documentation only from src.
 doc-gen:

--- a/template/Makefile.jinja
+++ b/template/Makefile.jinja
@@ -137,7 +137,7 @@ changelog:
 
 # Generate release notes from changelog.
 release-notes:
-	git-changelog --input $(CHANGELOG_PATH) --release-notes
+	@git-changelog --input $(CHANGELOG_PATH) --release-notes
 
 # Build documentation only from src.
 doc-gen:


### PR DESCRIPTION
In CI/CD, we will use `make release-notes > release-notes.md` to generate the release notes. Previously, the command `git-changelog --input docs/changelog.md --release-notes` will be included.

<!-- readthedocs-preview ss-python start -->
----
📚 Documentation preview 📚: https://ss-python--300.org.readthedocs.build/en/300/

<!-- readthedocs-preview ss-python end -->