### PR TITLE
ci: Remove redundant tag for dev container built on default branch.

### DIFF
--- a/.gitlab/workflows/devcontainer.yml
+++ b/.gitlab/workflows/devcontainer.yml
@@ -26,7 +26,6 @@ dev-container-publish:
         --provenance false \
         --push \
         --tag ${CI_REGISTRY_IMAGE}:dev-py${PYTHON_VERSION} \
-        --tag ${CI_REGISTRY_IMAGE}:dev-py${PYTHON_VERSION}-${CI_COMMIT_TAG} \
         --target dev
   services:
     - docker:dind

--- a/template/[% if repo_host_type == 'gitlab.com' or repo_host_type == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/devcontainer.yml.jinja
+++ b/template/[% if repo_host_type == 'gitlab.com' or repo_host_type == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/devcontainer.yml.jinja
@@ -37,7 +37,6 @@ dev-container-publish:
         --provenance false \
         --push \
         --tag ${CI_REGISTRY_IMAGE}:dev-py${PYTHON_VERSION} \
-        --tag ${CI_REGISTRY_IMAGE}:dev-py${PYTHON_VERSION}-${CI_COMMIT_TAG} \
         --target dev
   services:
     - docker:dind


### PR DESCRIPTION


<!-- readthedocs-preview ss-python start -->
----
📚 Documentation preview 📚: https://ss-python--302.org.readthedocs.build/en/302/

<!-- readthedocs-preview ss-python end -->