### PR TITLE
ci: Refine release notes generation.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,13 @@ jobs:
       - run: env | sort
       - run: make dev-doc
       - run: CI_PAGES_URL=${{ steps.pages.outputs.base_url }} make doc
-      - name: Upload changelog
+      - name: Generate release notes
+        run: make release-notes > release-notes.md
+      - name: Upload release notes
         uses: actions/upload-artifact@v4
         with:
-          name: changelog
-          path: docs/changelog.md
+          name: release-notes
+          path: release-notes.md
       - name: Upload pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
@@ -31,18 +33,11 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Install git-changelog using pipx
-        run: pipx install git-changelog
-      - name: Remove changelog to avoid file already exists error
-        run: rm -v docs/changelog.md
-      - name: Download changelog
+      - name: Download release notes
         uses: actions/download-artifact@v4
         with:
-          name: changelog
-          path: docs/
-      - name: Prepare release notes
-        run: make release-notes > release-notes.md
+          name: release-notes
+          path: release-notes.md
       - id: prerelease
         name: Determine prerelease
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: release-notes
-          path: release-notes.md
       - id: prerelease
         name: Determine prerelease
         run: |

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ changelog:
 
 # Generate release notes from changelog.
 release-notes:
-	@git-changelog --input $(CHANGELOG_PATH) --release-notes
+	@pdm run $(PDM_GLOBAL) git-changelog --input $(CHANGELOG_PATH) --release-notes
 
 # Build documentation only from src.
 doc-gen:

--- a/template/Makefile.jinja
+++ b/template/Makefile.jinja
@@ -137,7 +137,7 @@ changelog:
 
 # Generate release notes from changelog.
 release-notes:
-	@git-changelog --input $(CHANGELOG_PATH) --release-notes
+	@pdm run $(PDM_GLOBAL) git-changelog --input $(CHANGELOG_PATH) --release-notes
 
 # Build documentation only from src.
 doc-gen:

--- a/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/release.yml.jinja
+++ b/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/release.yml.jinja
@@ -17,11 +17,13 @@ jobs:
       - run: env | sort
       - run: make dev-doc
       - run: CI_PAGES_URL={{ '${{ steps.pages.outputs.base_url }}' }} make doc
-      - name: Upload changelog
+      - name: Generate release notes
+        run: make release-notes > release-notes.md
+      - name: Upload release notes
         uses: actions/upload-artifact@v4
         with:
-          name: changelog
-          path: docs/changelog.md
+          name: release-notes
+          path: release-notes.md
       - name: Upload pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
@@ -32,18 +34,10 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Install git-changelog using pipx
-        run: pipx install git-changelog
-      - name: Remove changelog to avoid file already exists error
-        run: rm -v docs/changelog.md
-      - name: Download changelog
+      - name: Download release notes
         uses: actions/download-artifact@v4
         with:
-          name: changelog
-          path: docs/
-      - name: Prepare release notes
-        run: make release-notes > release-notes.md
+          name: release-notes
       - id: prerelease
         name: Determine prerelease
         run: |


### PR DESCRIPTION
Previously, changelog and release-notes are generated in separate jobs. This makes the whole process much complicated with extra steps to fetch the repo, delete files to be overridden, install `git-changelog` separately. We even have to hack Makefile so as to use `git-changelog` without `pdm` installed. Actaully, the release notes can be generated in `pages-build` job and only release notes need to be uploaded to publish a release as artifacts. Moreover, this makes it consistent with what we do in GitLab CI/CD.

<!-- readthedocs-preview ss-python start -->
----
📚 Documentation preview 📚: https://ss-python--303.org.readthedocs.build/en/303/

<!-- readthedocs-preview ss-python end -->