### PR TITLE
chore: unify naming pattern for containers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,10 +14,10 @@
             ]
         }
     },
-    "image": "ghcr.io/serious-scaffold/ss-python:dev-py3.12",
+    "image": "ghcr.io/serious-scaffold/ss-python/dev:py3.12",
     // Force the image update to ensure the latest version which might be a bug.
     // Reference: https://github.com/microsoft/vscode-remote-release/issues/9391
-    "initializeCommand": "docker pull ghcr.io/serious-scaffold/ss-python:dev-py3.12",
+    "initializeCommand": "docker pull ghcr.io/serious-scaffold/ss-python/dev:py3.12",
     // Use a targeted named volume for .venv folder to improve disk performance.
     // Reference: https://code.visualstudio.com/remote/advancedcontainers/improve-performance#_use-a-targeted-named-volume
     "mounts": [

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -22,13 +22,13 @@ jobs:
         with:
           build-args: |
             PYTHON_VERSION=${{ matrix.python-version }}
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:build-cache-dev-py${{ matrix.python-version }}
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:build-cache-dev-py${{ matrix.python-version }},mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/build-cache-dev:py${{ matrix.python-version }}
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}/build-cache-dev:py${{ matrix.python-version }},mode=max
           file: .devcontainer/Dockerfile
           provenance: false
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}:dev-py${{ matrix.python-version }}
+            ghcr.io/${{ github.repository }}/dev:py${{ matrix.python-version }}
           target: dev
     strategy:
       matrix:

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -22,8 +22,8 @@ jobs:
         with:
           build-args: |
             PYTHON_VERSION=${{ matrix.python-version }}
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/build-cache-dev:py${{ matrix.python-version }}
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}/build-cache-dev:py${{ matrix.python-version }},mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/dev-cache:py${{ matrix.python-version }}
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}/dev-cache:py${{ matrix.python-version }},mode=max
           file: .devcontainer/Dockerfile
           provenance: false
           push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,14 +70,14 @@ jobs:
         with:
           build-args: |
             PYTHON_VERSION=${{ matrix.python-version }}
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:build-cache-dev-py${{ matrix.python-version }}
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:build-cache-dev-py${{ matrix.python-version }},mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/build-cache-dev:py${{ matrix.python-version }}
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}/build-cache-dev:py${{ matrix.python-version }},mode=max
           file: .devcontainer/Dockerfile
           provenance: false
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}:dev-py${{ matrix.python-version }}
-            ghcr.io/${{ github.repository }}:dev-py${{ matrix.python-version }}-${{ github.ref_name }}
+            ghcr.io/${{ github.repository }}/dev:py${{ matrix.python-version }}
+            ghcr.io/${{ github.repository }}/dev:py${{ matrix.python-version }}-${{ github.ref_name }}
           target: dev
       - name: Build and push prod container
         env:
@@ -87,13 +87,13 @@ jobs:
           build-args: |
             PYTHON_VERSION=${{ matrix.python-version }}
             PDM_BUILD_SCM_VERSION=${{ github.ref_name }}
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:build-cache-dev-py${{ matrix.python-version }}
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/build-cache-dev:py${{ matrix.python-version }}
           file: .devcontainer/Dockerfile
           provenance: false
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}:prod-py${{ matrix.python-version }}
-            ghcr.io/${{ github.repository }}:prod-py${{ matrix.python-version }}-${{ github.ref_name }}
+            ghcr.io/${{ github.repository }}/prod:py${{ matrix.python-version }}
+            ghcr.io/${{ github.repository }}/prod:py${{ matrix.python-version }}-${{ github.ref_name }}
           target: prod
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,8 +70,8 @@ jobs:
         with:
           build-args: |
             PYTHON_VERSION=${{ matrix.python-version }}
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/build-cache-dev:py${{ matrix.python-version }}
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}/build-cache-dev:py${{ matrix.python-version }},mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/dev-cache:py${{ matrix.python-version }}
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}/dev-cache:py${{ matrix.python-version }},mode=max
           file: .devcontainer/Dockerfile
           provenance: false
           push: true
@@ -87,13 +87,13 @@ jobs:
           build-args: |
             PYTHON_VERSION=${{ matrix.python-version }}
             PDM_BUILD_SCM_VERSION=${{ github.ref_name }}
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/build-cache-dev:py${{ matrix.python-version }}
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/dev-cache:py${{ matrix.python-version }}
           file: .devcontainer/Dockerfile
           provenance: false
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}/prod:py${{ matrix.python-version }}
-            ghcr.io/${{ github.repository }}/prod:py${{ matrix.python-version }}-${{ github.ref_name }}
+            ghcr.io/${{ github.repository }}:py${{ matrix.python-version }}
+            ghcr.io/${{ github.repository }}:py${{ matrix.python-version }}-${{ github.ref_name }}
           target: prod
     strategy:
       matrix:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,5 +5,5 @@ stages:
 default:
   before_script:
     - env | sort
-  image: ${CI_REGISTRY_IMAGE}:dev-py3.12
+  image: ${CI_REGISTRY_IMAGE}/dev:py3.12
 include: .gitlab/workflows/**.yml

--- a/.gitlab/workflows/ci.yml
+++ b/.gitlab/workflows/ci.yml
@@ -5,7 +5,7 @@ ci:
         coverage_format: cobertura
         path: coverage.xml
   coverage: /(?i)total.*? (100(?:\.0+)?\%|[1-9]?\d(?:\.\d+)?\%)$/
-  image: ${CI_REGISTRY_IMAGE}:dev-py${PYTHON_VERSION}
+  image: ${CI_REGISTRY_IMAGE}/dev:py${PYTHON_VERSION}
   interruptible: true
   parallel:
     matrix:

--- a/.gitlab/workflows/devcontainer.yml
+++ b/.gitlab/workflows/devcontainer.yml
@@ -20,8 +20,8 @@ dev-container-publish:
     - |
       docker buildx build . \
         --build-arg PYTHON_VERSION=${PYTHON_VERSION} \
-        --cache-from type=registry,ref=${CI_REGISTRY_IMAGE}/build-cache-dev:py${PYTHON_VERSION} \
-        --cache-to type=registry,ref=${CI_REGISTRY_IMAGE}/build-cache-dev:py${PYTHON_VERSION},mode=max \
+        --cache-from type=registry,ref=${CI_REGISTRY_IMAGE}/dev-cache:py${PYTHON_VERSION} \
+        --cache-to type=registry,ref=${CI_REGISTRY_IMAGE}/dev-cache:py${PYTHON_VERSION},mode=max \
         --file .devcontainer/Dockerfile \
         --provenance false \
         --push \

--- a/.gitlab/workflows/devcontainer.yml
+++ b/.gitlab/workflows/devcontainer.yml
@@ -20,12 +20,12 @@ dev-container-publish:
     - |
       docker buildx build . \
         --build-arg PYTHON_VERSION=${PYTHON_VERSION} \
-        --cache-from type=registry,ref=${CI_REGISTRY_IMAGE}:build-cache-dev-py${PYTHON_VERSION} \
-        --cache-to type=registry,ref=${CI_REGISTRY_IMAGE}:build-cache-dev-py${PYTHON_VERSION},mode=max \
+        --cache-from type=registry,ref=${CI_REGISTRY_IMAGE}/build-cache-dev:py${PYTHON_VERSION} \
+        --cache-to type=registry,ref=${CI_REGISTRY_IMAGE}/build-cache-dev:py${PYTHON_VERSION},mode=max \
         --file .devcontainer/Dockerfile \
         --provenance false \
         --push \
-        --tag ${CI_REGISTRY_IMAGE}:dev-py${PYTHON_VERSION} \
+        --tag ${CI_REGISTRY_IMAGE}/dev:py${PYTHON_VERSION} \
         --target dev
   services:
     - docker:dind

--- a/.gitlab/workflows/release.yml
+++ b/.gitlab/workflows/release.yml
@@ -45,8 +45,8 @@ container-publish:
     - |
       docker buildx build . \
         --build-arg PYTHON_VERSION=${PYTHON_VERSION} \
-        --cache-from type=registry,ref=${CI_REGISTRY_IMAGE}/build-cache-dev:py${PYTHON_VERSION} \
-        --cache-to type=registry,ref=${CI_REGISTRY_IMAGE}/build-cache-dev:py${PYTHON_VERSION},mode=max \
+        --cache-from type=registry,ref=${CI_REGISTRY_IMAGE}/dev-cache:py${PYTHON_VERSION} \
+        --cache-to type=registry,ref=${CI_REGISTRY_IMAGE}/dev-cache:py${PYTHON_VERSION},mode=max \
         --file .devcontainer/Dockerfile \
         --provenance false \
         --push \
@@ -57,12 +57,12 @@ container-publish:
       docker buildx build . \
         --build-arg PDM_BUILD_SCM_VERSION=${CI_COMMIT_TAG} \
         --build-arg PYTHON_VERSION=${PYTHON_VERSION} \
-        --cache-from type=registry,ref=${CI_REGISTRY_IMAGE}/build-cache-dev:py${PYTHON_VERSION} \
+        --cache-from type=registry,ref=${CI_REGISTRY_IMAGE}/dev-cache:py${PYTHON_VERSION} \
         --file .devcontainer/Dockerfile \
         --provenance false \
         --push \
-        --tag ${CI_REGISTRY_IMAGE}/prod:py${PYTHON_VERSION} \
-        --tag ${CI_REGISTRY_IMAGE}/prod:py${PYTHON_VERSION}-${CI_COMMIT_TAG} \
+        --tag ${CI_REGISTRY_IMAGE}:py${PYTHON_VERSION} \
+        --tag ${CI_REGISTRY_IMAGE}:py${PYTHON_VERSION}-${CI_COMMIT_TAG} \
         --target prod
   services:
     - docker:dind

--- a/.gitlab/workflows/release.yml
+++ b/.gitlab/workflows/release.yml
@@ -45,24 +45,24 @@ container-publish:
     - |
       docker buildx build . \
         --build-arg PYTHON_VERSION=${PYTHON_VERSION} \
-        --cache-from type=registry,ref=${CI_REGISTRY_IMAGE}:build-cache-dev-py${PYTHON_VERSION} \
-        --cache-to type=registry,ref=${CI_REGISTRY_IMAGE}:build-cache-dev-py${PYTHON_VERSION},mode=max \
+        --cache-from type=registry,ref=${CI_REGISTRY_IMAGE}/build-cache-dev:py${PYTHON_VERSION} \
+        --cache-to type=registry,ref=${CI_REGISTRY_IMAGE}/build-cache-dev:py${PYTHON_VERSION},mode=max \
         --file .devcontainer/Dockerfile \
         --provenance false \
         --push \
-        --tag ${CI_REGISTRY_IMAGE}:dev-py${PYTHON_VERSION} \
-        --tag ${CI_REGISTRY_IMAGE}:dev-py${PYTHON_VERSION}-${CI_COMMIT_TAG} \
+        --tag ${CI_REGISTRY_IMAGE}/dev:py${PYTHON_VERSION} \
+        --tag ${CI_REGISTRY_IMAGE}/dev:py${PYTHON_VERSION}-${CI_COMMIT_TAG} \
         --target dev
     - |
       docker buildx build . \
         --build-arg PDM_BUILD_SCM_VERSION=${CI_COMMIT_TAG} \
         --build-arg PYTHON_VERSION=${PYTHON_VERSION} \
-        --cache-from type=registry,ref=${CI_REGISTRY_IMAGE}:build-cache-dev-py${PYTHON_VERSION} \
+        --cache-from type=registry,ref=${CI_REGISTRY_IMAGE}/build-cache-dev:py${PYTHON_VERSION} \
         --file .devcontainer/Dockerfile \
         --provenance false \
         --push \
-        --tag ${CI_REGISTRY_IMAGE}:prod-py${PYTHON_VERSION} \
-        --tag ${CI_REGISTRY_IMAGE}:prod-py${PYTHON_VERSION}-${CI_COMMIT_TAG} \
+        --tag ${CI_REGISTRY_IMAGE}/prod:py${PYTHON_VERSION} \
+        --tag ${CI_REGISTRY_IMAGE}/prod:py${PYTHON_VERSION}-${CI_COMMIT_TAG} \
         --target prod
   services:
     - docker:dind

--- a/docs/dev/proj.md
+++ b/docs/dev/proj.md
@@ -56,7 +56,7 @@ pipx install copier
 
     :::{tab-item} GitHub
     :sync: github
-    Open the [Dev Container Workflow](https://github.com/serious-scaffold/ss-python/actions/workflows/devcontainer.yml) page and run the workflow from the default branch.
+    Navigate to the [Dev Container Workflow](https://github.com/serious-scaffold/ss-python/actions/workflows/devcontainer.yml) page and run workflow from the default branch. The container will be named following pattern `ghcr.io/serious-scaffold/ss-python/dev:py<PYTHON_VERSION>`, for example, `ghcr.io/serious-scaffold/ss-python/dev:py3.12`.
 
     ```{image} /_static/images/bootstrap-dev-container-github.png
     :alt: Bootstrap Dev Container on GitHub.
@@ -67,7 +67,7 @@ pipx install copier
 
     :::{tab-item} GitLab
     :sync: gitlab
-    Open the [Run pipeline](https://gitlab.com/serious-scaffold/ss-python/-/pipelines/new) page and run pipeline for the default branch.
+    Navigate to the [Run pipeline](https://gitlab.com/serious-scaffold/ss-python/-/pipelines/new) page and run pipeline for the default branch. The container will be named following pattern `registry.gitlab.com/serious-scaffold/ss-python/dev:py<PYTHON_VERSION>`, for example, `registry.gitlab.com/serious-scaffold/ss-python/dev:py3.12`.
 
     ```{image} /_static/images/bootstrap-dev-container-gitlab.png
     :alt: Bootstrap Dev Container on GitLab.

--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -11,11 +11,11 @@ The release process includes the following tasks:
 
 1. Publish a new GitHub Release.
 1. Build and publish the documentation to GitHub Pages.
-1. Build and publish the Python package to the configured package repository.
-1. Build and publish the Development and Production Containers with build cache to GitHub Packages.
-    1. Production container named in pattern `ghcr.io/serious-scaffold/ss-python:py<PYTHON_VERSION>`.
-    1. Development container named in pattern `ghcr.io/serious-scaffold/ss-python/dev:py<PYTHON_VERSION>`.
-    1. Build cache for development container named in pattern `ghcr.io/serious-scaffold/ss-python/dev-cache:py<PYTHON_VERSION>`.
+1. Build and publish the Python package to the designated package repository.
+1. Build and publish the Development and Production Containers with the build cache to GitHub Packages.
+    1. The Production Container is tagged as `ghcr.io/serious-scaffold/ss-python:py<PYTHON_VERSION>` for the latest version and `ghcr.io/serious-scaffold/ss-python:py<PYTHON_VERSION>-<PROJECT_VERSION>` for archives.
+    1. The Development Container is tagged as `ghcr.io/serious-scaffold/ss-python/dev:py<PYTHON_VERSION>` for the latest version and `ghcr.io/serious-scaffold/ss-python/dev:py<PYTHON_VERSION>-<PROJECT_VERSION>` for archives.
+    1. Build cache for the Development Container is tagged as `ghcr.io/serious-scaffold/ss-python/dev-cache:py<PYTHON_VERSION>`.
 
 :::
 
@@ -26,9 +26,9 @@ The release process includes the following tasks:
 1. Build and publish the documentation to GitLab Pages.
 1. Build and publish the Python package to the configured package repository.
 1. Build and publish the Development and Production Containers with build cache to GitLab Container Registry.
-    1. Production container named in pattern `registry.gitlab.com/serious-scaffold/ss-python:py<PYTHON_VERSION>`.
-    1. Development container named in pattern `registry.gitlab.com/serious-scaffold/ss-python/dev:py<PYTHON_VERSION>`.
-    1. Build cache for development container named in pattern `registry.gitlab.com/serious-scaffold/ss-python/dev-cache:py<PYTHON_VERSION>`.
+    1. The Production Container is tagged as `registry.gitlab.com/serious-scaffold/ss-python:py<PYTHON_VERSION>` for the latest version and `registry.gitlab.com/serious-scaffold/ss-python:py<PYTHON_VERSION>-<PROJECT_VERSION>` for archives.
+    1. The Development Container is tagged as `registry.gitlab.com/serious-scaffold/ss-python/dev:py<PYTHON_VERSION>` for the latest version and `registry.gitlab.com/serious-scaffold/ss-python/dev:py<PYTHON_VERSION>-<PROJECT_VERSION>` for archives.
+    1. Build cache for the Development Container is tagged as `registry.gitlab.com/serious-scaffold/ss-python/dev-cache:py<PYTHON_VERSION>`.
 
 :::
 

--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -12,7 +12,10 @@ The release process includes the following tasks:
 1. Publish a new GitHub Release.
 1. Build and publish the documentation to GitHub Pages.
 1. Build and publish the Python package to the configured package repository.
-1. Build and publish the Development and Production Containers to GitHub Packages.
+1. Build and publish the Development and Production Containers with build cache to GitHub Packages.
+    1. Production container named in pattern `ghcr.io/serious-scaffold/ss-python:py<PYTHON_VERSION>`.
+    1. Development container named in pattern `ghcr.io/serious-scaffold/ss-python/dev:py<PYTHON_VERSION>`.
+    1. Build cache for development container named in pattern `ghcr.io/serious-scaffold/ss-python/dev-cache:py<PYTHON_VERSION>`.
 
 :::
 
@@ -22,7 +25,10 @@ The release process includes the following tasks:
 1. Publish a new GitLab Release.
 1. Build and publish the documentation to GitLab Pages.
 1. Build and publish the Python package to the configured package repository.
-1. Build and publish the Development and Production Containers to GitLab Container Registry.
+1. Build and publish the Development and Production Containers with build cache to GitLab Container Registry.
+    1. Production container named in pattern `registry.gitlab.com/serious-scaffold/ss-python:py<PYTHON_VERSION>`.
+    1. Development container named in pattern `registry.gitlab.com/serious-scaffold/ss-python/dev:py<PYTHON_VERSION>`.
+    1. Build cache for development container named in pattern `registry.gitlab.com/serious-scaffold/ss-python/dev-cache:py<PYTHON_VERSION>`.
 
 :::
 

--- a/template/.devcontainer/devcontainer.json.jinja
+++ b/template/.devcontainer/devcontainer.json.jinja
@@ -14,10 +14,10 @@
             ]
         }
     },
-    "image": "{{ container_registry_host }}/{{ repo_namespace }}/{{ repo_name }}:dev-py{{ default_py }}",
+    "image": "{{ container_registry_host }}/{{ repo_namespace }}/{{ repo_name }}/dev:py{{ default_py }}",
     // Force the image update to ensure the latest version which might be a bug.
     // Reference: https://github.com/microsoft/vscode-remote-release/issues/9391
-    "initializeCommand": "docker pull {{ container_registry_host }}/{{ repo_namespace }}/{{ repo_name }}:dev-py{{ default_py }}",
+    "initializeCommand": "docker pull {{ container_registry_host }}/{{ repo_namespace }}/{{ repo_name }}/dev:py{{ default_py }}",
     // Use a targeted named volume for .venv folder to improve disk performance.
     // Reference: https://code.visualstudio.com/remote/advancedcontainers/improve-performance#_use-a-targeted-named-volume
     "mounts": [

--- a/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/devcontainer.yml.jinja
+++ b/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/devcontainer.yml.jinja
@@ -23,13 +23,13 @@ jobs:
         with:
           build-args: |
             PYTHON_VERSION={{ '${{ matrix.python-version }}' }}
-          cache-from: type=registry,ref=ghcr.io/{{ '${{ github.repository }}' }}:build-cache-dev-py{{ '${{ matrix.python-version }}' }}
-          cache-to: type=registry,ref=ghcr.io/{{ '${{ github.repository }}' }}:build-cache-dev-py{{ '${{ matrix.python-version }}' }},mode=max
+          cache-from: type=registry,ref=ghcr.io/{{ '${{ github.repository }}' }}/build-cache-dev:py{{ '${{ matrix.python-version }}' }}
+          cache-to: type=registry,ref=ghcr.io/{{ '${{ github.repository }}' }}/build-cache-dev:py{{ '${{ matrix.python-version }}' }},mode=max
           file: .devcontainer/Dockerfile
           provenance: false
           push: true
           tags: |
-            ghcr.io/{{ '${{ github.repository }}' }}:dev-py{{ '${{ matrix.python-version }}' }}
+            ghcr.io/{{ '${{ github.repository }}' }}/dev:py{{ '${{ matrix.python-version }}' }}
           target: dev
     strategy:
       matrix:

--- a/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/devcontainer.yml.jinja
+++ b/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/devcontainer.yml.jinja
@@ -23,8 +23,8 @@ jobs:
         with:
           build-args: |
             PYTHON_VERSION={{ '${{ matrix.python-version }}' }}
-          cache-from: type=registry,ref=ghcr.io/{{ '${{ github.repository }}' }}/build-cache-dev:py{{ '${{ matrix.python-version }}' }}
-          cache-to: type=registry,ref=ghcr.io/{{ '${{ github.repository }}' }}/build-cache-dev:py{{ '${{ matrix.python-version }}' }},mode=max
+          cache-from: type=registry,ref=ghcr.io/{{ '${{ github.repository }}' }}/dev-cache:py{{ '${{ matrix.python-version }}' }}
+          cache-to: type=registry,ref=ghcr.io/{{ '${{ github.repository }}' }}/dev-cache:py{{ '${{ matrix.python-version }}' }},mode=max
           file: .devcontainer/Dockerfile
           provenance: false
           push: true

--- a/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/release.yml.jinja
+++ b/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/release.yml.jinja
@@ -71,8 +71,8 @@ jobs:
         with:
           build-args: |
             PYTHON_VERSION={{ '${{ matrix.python-version }}' }}
-          cache-from: type=registry,ref=ghcr.io/{{ '${{ github.repository }}' }}/build-cache-dev:py{{ '${{ matrix.python-version }}' }}
-          cache-to: type=registry,ref=ghcr.io/{{ '${{ github.repository }}' }}/build-cache-dev:py{{ '${{ matrix.python-version }}' }},mode=max
+          cache-from: type=registry,ref=ghcr.io/{{ '${{ github.repository }}' }}/dev-cache:py{{ '${{ matrix.python-version }}' }}
+          cache-to: type=registry,ref=ghcr.io/{{ '${{ github.repository }}' }}/dev-cache:py{{ '${{ matrix.python-version }}' }},mode=max
           file: .devcontainer/Dockerfile
           provenance: false
           push: true
@@ -88,13 +88,13 @@ jobs:
           build-args: |
             PYTHON_VERSION={{ '${{ matrix.python-version }}' }}
             PDM_BUILD_SCM_VERSION={{ '${{ github.ref_name }}' }}
-          cache-from: type=registry,ref=ghcr.io/{{ '${{ github.repository }}' }}/build-cache-dev:py{{ '${{ matrix.python-version }}' }}
+          cache-from: type=registry,ref=ghcr.io/{{ '${{ github.repository }}' }}/dev-cache:py{{ '${{ matrix.python-version }}' }}
           file: .devcontainer/Dockerfile
           provenance: false
           push: true
           tags: |
-            ghcr.io/{{ '${{ github.repository }}' }}/prod:py{{ '${{ matrix.python-version }}' }}
-            ghcr.io/{{ '${{ github.repository }}' }}/prod:py{{ '${{ matrix.python-version }}' }}-{{ '${{ github.ref_name }}' }}
+            ghcr.io/{{ '${{ github.repository }}' }}:py{{ '${{ matrix.python-version }}' }}
+            ghcr.io/{{ '${{ github.repository }}' }}:py{{ '${{ matrix.python-version }}' }}-{{ '${{ github.ref_name }}' }}
           target: prod
     strategy:
       matrix:

--- a/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/release.yml.jinja
+++ b/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/release.yml.jinja
@@ -71,14 +71,14 @@ jobs:
         with:
           build-args: |
             PYTHON_VERSION={{ '${{ matrix.python-version }}' }}
-          cache-from: type=registry,ref=ghcr.io/{{ '${{ github.repository }}' }}:build-cache-dev-py{{ '${{ matrix.python-version }}' }}
-          cache-to: type=registry,ref=ghcr.io/{{ '${{ github.repository }}' }}:build-cache-dev-py{{ '${{ matrix.python-version }}' }},mode=max
+          cache-from: type=registry,ref=ghcr.io/{{ '${{ github.repository }}' }}/build-cache-dev:py{{ '${{ matrix.python-version }}' }}
+          cache-to: type=registry,ref=ghcr.io/{{ '${{ github.repository }}' }}/build-cache-dev:py{{ '${{ matrix.python-version }}' }},mode=max
           file: .devcontainer/Dockerfile
           provenance: false
           push: true
           tags: |
-            ghcr.io/{{ '${{ github.repository }}' }}:dev-py{{ '${{ matrix.python-version }}' }}
-            ghcr.io/{{ '${{ github.repository }}' }}:dev-py{{ '${{ matrix.python-version }}' }}-{{ '${{ github.ref_name }}' }}
+            ghcr.io/{{ '${{ github.repository }}' }}/dev:py{{ '${{ matrix.python-version }}' }}
+            ghcr.io/{{ '${{ github.repository }}' }}/dev:py{{ '${{ matrix.python-version }}' }}-{{ '${{ github.ref_name }}' }}
           target: dev
       - name: Build and push prod container
         env:
@@ -88,13 +88,13 @@ jobs:
           build-args: |
             PYTHON_VERSION={{ '${{ matrix.python-version }}' }}
             PDM_BUILD_SCM_VERSION={{ '${{ github.ref_name }}' }}
-          cache-from: type=registry,ref=ghcr.io/{{ '${{ github.repository }}' }}:build-cache-dev-py{{ '${{ matrix.python-version }}' }}
+          cache-from: type=registry,ref=ghcr.io/{{ '${{ github.repository }}' }}/build-cache-dev:py{{ '${{ matrix.python-version }}' }}
           file: .devcontainer/Dockerfile
           provenance: false
           push: true
           tags: |
-            ghcr.io/{{ '${{ github.repository }}' }}:prod-py{{ '${{ matrix.python-version }}' }}
-            ghcr.io/{{ '${{ github.repository }}' }}:prod-py{{ '${{ matrix.python-version }}' }}-{{ '${{ github.ref_name }}' }}
+            ghcr.io/{{ '${{ github.repository }}' }}/prod:py{{ '${{ matrix.python-version }}' }}
+            ghcr.io/{{ '${{ github.repository }}' }}/prod:py{{ '${{ matrix.python-version }}' }}-{{ '${{ github.ref_name }}' }}
           target: prod
     strategy:
       matrix:

--- a/template/[% if repo_host_type == 'gitlab.com' or repo_host_type == 'gitlab-self-managed' %].gitlab-ci.yml[% endif %].jinja
+++ b/template/[% if repo_host_type == 'gitlab.com' or repo_host_type == 'gitlab-self-managed' %].gitlab-ci.yml[% endif %].jinja
@@ -5,5 +5,5 @@ stages:
 default:
   before_script:
     - env | sort
-  image: ${CI_REGISTRY_IMAGE}:dev-py{{ default_py }}
+  image: ${CI_REGISTRY_IMAGE}/dev:py{{ default_py }}
 include: .gitlab/workflows/**.yml

--- a/template/[% if repo_host_type == 'gitlab.com' or repo_host_type == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/ci.yml.jinja
+++ b/template/[% if repo_host_type == 'gitlab.com' or repo_host_type == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/ci.yml.jinja
@@ -6,7 +6,7 @@ ci:
         coverage_format: cobertura
         path: coverage.xml
   coverage: /(?i)total.*? (100(?:\.0+)?\%|[1-9]?\d(?:\.\d+)?\%)$/
-  image: ${CI_REGISTRY_IMAGE}:dev-py${PYTHON_VERSION}
+  image: ${CI_REGISTRY_IMAGE}/dev:py${PYTHON_VERSION}
   interruptible: true
   parallel:
     matrix:

--- a/template/[% if repo_host_type == 'gitlab.com' or repo_host_type == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/devcontainer.yml.jinja
+++ b/template/[% if repo_host_type == 'gitlab.com' or repo_host_type == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/devcontainer.yml.jinja
@@ -31,12 +31,12 @@ dev-container-publish:
     - |
       docker buildx build . \
         --build-arg PYTHON_VERSION=${PYTHON_VERSION} \
-        --cache-from type=registry,ref=${CI_REGISTRY_IMAGE}:build-cache-dev-py${PYTHON_VERSION} \
-        --cache-to type=registry,ref=${CI_REGISTRY_IMAGE}:build-cache-dev-py${PYTHON_VERSION},mode=max \
+        --cache-from type=registry,ref=${CI_REGISTRY_IMAGE}/build-cache-dev:py${PYTHON_VERSION} \
+        --cache-to type=registry,ref=${CI_REGISTRY_IMAGE}/build-cache-dev:py${PYTHON_VERSION},mode=max \
         --file .devcontainer/Dockerfile \
         --provenance false \
         --push \
-        --tag ${CI_REGISTRY_IMAGE}:dev-py${PYTHON_VERSION} \
+        --tag ${CI_REGISTRY_IMAGE}/dev:py${PYTHON_VERSION} \
         --target dev
   services:
     - docker:dind

--- a/template/[% if repo_host_type == 'gitlab.com' or repo_host_type == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/devcontainer.yml.jinja
+++ b/template/[% if repo_host_type == 'gitlab.com' or repo_host_type == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/devcontainer.yml.jinja
@@ -31,8 +31,8 @@ dev-container-publish:
     - |
       docker buildx build . \
         --build-arg PYTHON_VERSION=${PYTHON_VERSION} \
-        --cache-from type=registry,ref=${CI_REGISTRY_IMAGE}/build-cache-dev:py${PYTHON_VERSION} \
-        --cache-to type=registry,ref=${CI_REGISTRY_IMAGE}/build-cache-dev:py${PYTHON_VERSION},mode=max \
+        --cache-from type=registry,ref=${CI_REGISTRY_IMAGE}/dev-cache:py${PYTHON_VERSION} \
+        --cache-to type=registry,ref=${CI_REGISTRY_IMAGE}/dev-cache:py${PYTHON_VERSION},mode=max \
         --file .devcontainer/Dockerfile \
         --provenance false \
         --push \

--- a/template/[% if repo_host_type == 'gitlab.com' or repo_host_type == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/release.yml.jinja
+++ b/template/[% if repo_host_type == 'gitlab.com' or repo_host_type == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/release.yml.jinja
@@ -56,24 +56,24 @@ container-publish:
     - |
       docker buildx build . \
         --build-arg PYTHON_VERSION=${PYTHON_VERSION} \
-        --cache-from type=registry,ref=${CI_REGISTRY_IMAGE}:build-cache-dev-py${PYTHON_VERSION} \
-        --cache-to type=registry,ref=${CI_REGISTRY_IMAGE}:build-cache-dev-py${PYTHON_VERSION},mode=max \
+        --cache-from type=registry,ref=${CI_REGISTRY_IMAGE}/build-cache-dev:py${PYTHON_VERSION} \
+        --cache-to type=registry,ref=${CI_REGISTRY_IMAGE}/build-cache-dev:py${PYTHON_VERSION},mode=max \
         --file .devcontainer/Dockerfile \
         --provenance false \
         --push \
-        --tag ${CI_REGISTRY_IMAGE}:dev-py${PYTHON_VERSION} \
-        --tag ${CI_REGISTRY_IMAGE}:dev-py${PYTHON_VERSION}-${CI_COMMIT_TAG} \
+        --tag ${CI_REGISTRY_IMAGE}/dev:py${PYTHON_VERSION} \
+        --tag ${CI_REGISTRY_IMAGE}/dev:py${PYTHON_VERSION}-${CI_COMMIT_TAG} \
         --target dev
     - |
       docker buildx build . \
         --build-arg PDM_BUILD_SCM_VERSION=${CI_COMMIT_TAG} \
         --build-arg PYTHON_VERSION=${PYTHON_VERSION} \
-        --cache-from type=registry,ref=${CI_REGISTRY_IMAGE}:build-cache-dev-py${PYTHON_VERSION} \
+        --cache-from type=registry,ref=${CI_REGISTRY_IMAGE}/build-cache-dev:py${PYTHON_VERSION} \
         --file .devcontainer/Dockerfile \
         --provenance false \
         --push \
-        --tag ${CI_REGISTRY_IMAGE}:prod-py${PYTHON_VERSION} \
-        --tag ${CI_REGISTRY_IMAGE}:prod-py${PYTHON_VERSION}-${CI_COMMIT_TAG} \
+        --tag ${CI_REGISTRY_IMAGE}/prod:py${PYTHON_VERSION} \
+        --tag ${CI_REGISTRY_IMAGE}/prod:py${PYTHON_VERSION}-${CI_COMMIT_TAG} \
         --target prod
   services:
     - docker:dind

--- a/template/[% if repo_host_type == 'gitlab.com' or repo_host_type == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/release.yml.jinja
+++ b/template/[% if repo_host_type == 'gitlab.com' or repo_host_type == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/release.yml.jinja
@@ -56,8 +56,8 @@ container-publish:
     - |
       docker buildx build . \
         --build-arg PYTHON_VERSION=${PYTHON_VERSION} \
-        --cache-from type=registry,ref=${CI_REGISTRY_IMAGE}/build-cache-dev:py${PYTHON_VERSION} \
-        --cache-to type=registry,ref=${CI_REGISTRY_IMAGE}/build-cache-dev:py${PYTHON_VERSION},mode=max \
+        --cache-from type=registry,ref=${CI_REGISTRY_IMAGE}/dev-cache:py${PYTHON_VERSION} \
+        --cache-to type=registry,ref=${CI_REGISTRY_IMAGE}/dev-cache:py${PYTHON_VERSION},mode=max \
         --file .devcontainer/Dockerfile \
         --provenance false \
         --push \
@@ -68,12 +68,12 @@ container-publish:
       docker buildx build . \
         --build-arg PDM_BUILD_SCM_VERSION=${CI_COMMIT_TAG} \
         --build-arg PYTHON_VERSION=${PYTHON_VERSION} \
-        --cache-from type=registry,ref=${CI_REGISTRY_IMAGE}/build-cache-dev:py${PYTHON_VERSION} \
+        --cache-from type=registry,ref=${CI_REGISTRY_IMAGE}/dev-cache:py${PYTHON_VERSION} \
         --file .devcontainer/Dockerfile \
         --provenance false \
         --push \
-        --tag ${CI_REGISTRY_IMAGE}/prod:py${PYTHON_VERSION} \
-        --tag ${CI_REGISTRY_IMAGE}/prod:py${PYTHON_VERSION}-${CI_COMMIT_TAG} \
+        --tag ${CI_REGISTRY_IMAGE}:py${PYTHON_VERSION} \
+        --tag ${CI_REGISTRY_IMAGE}:py${PYTHON_VERSION}-${CI_COMMIT_TAG} \
         --target prod
   services:
     - docker:dind

--- a/template/docs/dev/proj.md.jinja
+++ b/template/docs/dev/proj.md.jinja
@@ -56,7 +56,7 @@ pipx install copier
 
     :::{tab-item} GitHub
     :sync: github
-    Open the [Dev Container Workflow](https://github.com/{{ repo_namespace }}/{{ repo_name }}/actions/workflows/devcontainer.yml) page and run the workflow from the default branch.
+    Navigate to the [Dev Container Workflow](https://github.com/{{ repo_namespace }}/{{ repo_name }}/actions/workflows/devcontainer.yml) page and run workflow from the default branch. The container will be named following pattern `ghcr.io/{{ repo_namespace }}/{{ repo_name }}/dev:py<PYTHON_VERSION>`, for example, `ghcr.io/{{ repo_namespace }}/{{ repo_name }}/dev:py3.12`.
 
     ```{image} /_static/images/bootstrap-dev-container-github.png
     :alt: Bootstrap Dev Container on GitHub.
@@ -67,7 +67,7 @@ pipx install copier
 
     :::{tab-item} GitLab
     :sync: gitlab
-    Open the [Run pipeline](https://gitlab.com/{{ repo_namespace }}/{{ repo_name }}/-/pipelines/new) page and run pipeline for the default branch.
+    Navigate to the [Run pipeline](https://gitlab.com/{{ repo_namespace }}/{{ repo_name }}/-/pipelines/new) page and run pipeline for the default branch. The container will be named following pattern `registry.gitlab.com/{{ repo_namespace }}/{{ repo_name }}/dev:py<PYTHON_VERSION>`, for example, `registry.gitlab.com/{{ repo_namespace }}/{{ repo_name }}/dev:py3.12`.
 
     ```{image} /_static/images/bootstrap-dev-container-gitlab.png
     :alt: Bootstrap Dev Container on GitLab.

--- a/template/docs/dev/release.md.jinja
+++ b/template/docs/dev/release.md.jinja
@@ -11,8 +11,11 @@ The release process includes the following tasks:
 
 1. Publish a new GitHub Release.
 1. Build and publish the documentation to GitHub Pages.
-1. Build and publish the Python package to the configured package repository.
-1. Build and publish the Development and Production Containers to GitHub Packages.
+1. Build and publish the Python package to the designated package repository.
+1. Build and publish the Development and Production Containers with the build cache to GitHub Packages.
+    1. The Production Container is tagged as `ghcr.io/{{ repo_namespace }}/{{ repo_name }}:py<PYTHON_VERSION>` for the latest version and `ghcr.io/{{ repo_namespace }}/{{ repo_name }}:py<PYTHON_VERSION>-<PROJECT_VERSION>` for archives.
+    1. The Development Container is tagged as `ghcr.io/{{ repo_namespace }}/{{ repo_name }}/dev:py<PYTHON_VERSION>` for the latest version and `ghcr.io/{{ repo_namespace }}/{{ repo_name }}/dev:py<PYTHON_VERSION>-<PROJECT_VERSION>` for archives.
+    1. Build cache for the Development Container is tagged as `ghcr.io/{{ repo_namespace }}/{{ repo_name }}/dev-cache:py<PYTHON_VERSION>`.
 
 :::
 
@@ -22,7 +25,10 @@ The release process includes the following tasks:
 1. Publish a new GitLab Release.
 1. Build and publish the documentation to GitLab Pages.
 1. Build and publish the Python package to the configured package repository.
-1. Build and publish the Development and Production Containers to GitLab Container Registry.
+1. Build and publish the Development and Production Containers with build cache to GitLab Container Registry.
+    1. The Production Container is tagged as `registry.gitlab.com/{{ repo_namespace }}/{{ repo_name }}:py<PYTHON_VERSION>` for the latest version and `registry.gitlab.com/{{ repo_namespace }}/{{ repo_name }}:py<PYTHON_VERSION>-<PROJECT_VERSION>` for archives.
+    1. The Development Container is tagged as `registry.gitlab.com/{{ repo_namespace }}/{{ repo_name }}/dev:py<PYTHON_VERSION>` for the latest version and `registry.gitlab.com/{{ repo_namespace }}/{{ repo_name }}/dev:py<PYTHON_VERSION>-<PROJECT_VERSION>` for archives.
+    1. Build cache for the Development Container is tagged as `registry.gitlab.com/{{ repo_namespace }}/{{ repo_name }}/dev-cache:py<PYTHON_VERSION>`.
 
 :::
 


### PR DESCRIPTION
Previously, we use a single repository and differentiated containers solely based on tags. Taking project versions into consideration has made this approach more complicated. Here we unify the containers naming pattern into three categories:

- `ghcr.io/serious-scaffold/ss-python:py3.12` for production image.
- `ghcr.io/serious-scaffold/ss-python/dev:py3.12` for development image.
- `ghcr.io/serious-scaffold/ss-python/dev-cache:py3.12` for build cache of development image.

In the furture, when we have build cache of production image, we can still leverage the similar pattern.

<!-- readthedocs-preview ss-python start -->
----
📚 Documentation preview 📚: https://ss-python--309.org.readthedocs.build/en/309/

<!-- readthedocs-preview ss-python end -->