### PR TITLE
ci: dynamic CI_PAGES_URL env for ci workflow on GitHub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,15 @@ jobs:
         with:
           cache: true
           python-version: ${{ matrix.python-version }}
+      - id: pages
+        name: Setup pages
+        uses: actions/configure-pages@v4
       - run: env | sort
       - run: make dev
-      - run: make lint test doc build
+      - run: make lint
+      - run: make test
+      - run: CI_PAGES_URL=${{ steps.pages.outputs.base_url }} make doc
+      - run: make build
     strategy:
       matrix:
         python-version:

--- a/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/ci.yml.jinja
+++ b/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/ci.yml.jinja
@@ -15,9 +15,15 @@ jobs:
         with:
           cache: true
           python-version: {{ '${{ matrix.python-version }}' }}
+      - id: pages
+        name: Setup pages
+        uses: actions/configure-pages@v4
       - run: env | sort
       - run: make dev
-      - run: make lint test doc build
+      - run: make lint
+      - run: make test
+      - run: CI_PAGES_URL={{ '${{ steps.pages.outputs.base_url }}' }} make doc
+      - run: make build
     strategy:
       matrix:
         python-version:


### PR DESCRIPTION
This fixes ci workflow on the main branch in forked repo.

Reference: https://github.com/huxuan/ss-python/actions/workflows/ci.yml

<!-- readthedocs-preview ss-python start -->
----
📚 Documentation preview 📚: https://ss-python--311.org.readthedocs.build/en/311/

<!-- readthedocs-preview ss-python end -->