### PR TITLE
chore: add initial version of renovate config

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,29 @@
+name: Renovate
+jobs:
+  renovate:
+    container:
+      env:
+        LOG_LEVEL: debug
+        RENOVATE_BRANCH_PREFIX: renovate-github/
+        RENOVATE_ENABLED_MANAGERS: '["pep621", "github-actions"]'
+        RENOVATE_GIT_AUTHOR: Renovate GitHub Bot <github@renovatebot.com>
+        RENOVATE_OPTIMIZE_FOR_DISABLED: 'true'
+        RENOVATE_PLATFORM: github
+        RENOVATE_REPOSITORIES: '["${{ github.repository }}"]'
+        RENOVATE_REPOSITORY_CACHE: enabled
+        RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN }}
+      image: ghcr.io/renovatebot/renovate:37.202.2
+    runs-on: ubuntu-latest
+    steps:
+      - run: env | sort
+      - run: |
+          if [ -z "${{ secrets.RENOVATE_TOKEN }}" ]; then
+            echo "RENOVATE_TOKEN not set, skipping ..."
+          else
+            renovate $RENOVATE_EXTRA_FLAG
+          fi
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron: '0 * * * 0,6'
+  workflow_dispatch: null

--- a/.gitlab/workflows/ci.yml
+++ b/.gitlab/workflows/ci.yml
@@ -16,7 +16,7 @@ ci:
           - '3.11'
           - '3.12'
   rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push"
     - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
   script:
     - make dev

--- a/.gitlab/workflows/commitlint.yml
+++ b/.gitlab/workflows/commitlint.yml
@@ -4,7 +4,7 @@ commitlint:
     entrypoint: [""]
   interruptible: true
   rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push"
     - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
   script:
     - |

--- a/.gitlab/workflows/devcontainer.yml
+++ b/.gitlab/workflows/devcontainer.yml
@@ -11,7 +11,8 @@ dev-container-publish:
   rules:
     - changes:
         - .devcontainer/Dockerfile
-      if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+      if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "web"
   script:
     - docker login -u ${CI_REGISTRY_USER} -p ${CI_REGISTRY_PASSWORD} ${CI_REGISTRY}
     - docker context create builder

--- a/.gitlab/workflows/renovate.yml
+++ b/.gitlab/workflows/renovate.yml
@@ -1,0 +1,27 @@
+renovate:
+  cache:
+    key: ${CI_COMMIT_REF_SLUG}-renovate
+    paths:
+      - renovate/cache/renovate/repository/
+  image: renovate/renovate:37.202.2
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+  script:
+    - |
+      if [ -z "$RENOVATE_TOKEN" ]; then
+        echo "RENOVATE_TOKEN not set, skipping ..."
+      else
+        renovate $RENOVATE_EXTRA_FLAG
+      fi
+  stage: build
+  variables:
+    LOG_LEVEL: debug
+    RENOVATE_BASE_DIR: $CI_PROJECT_DIR/renovate
+    RENOVATE_BRANCH_PREFIX: renovate-gitlab/
+    RENOVATE_ENABLED_MANAGERS: '["pep621"]'
+    RENOVATE_ENDPOINT: $CI_API_V4_URL
+    RENOVATE_GIT_AUTHOR: Renovate GitLab Bot <gitlab@renovatebot.com>
+    RENOVATE_OPTIMIZE_FOR_DISABLED: 'true'
+    RENOVATE_PLATFORM: gitlab
+    RENOVATE_REPOSITORIES: '["$CI_PROJECT_PATH"]'
+    RENOVATE_REPOSITORY_CACHE: enabled

--- a/.gitlab/workflows/renovate.yml
+++ b/.gitlab/workflows/renovate.yml
@@ -5,14 +5,8 @@ renovate:
       - renovate/cache/renovate/repository/
   image: renovate/renovate:37.202.2
   rules:
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-  script:
-    - |
-      if [ -z "$RENOVATE_TOKEN" ]; then
-        echo "RENOVATE_TOKEN not set, skipping ..."
-      else
-        renovate $RENOVATE_EXTRA_FLAG
-      fi
+    - if: $CI_PIPELINE_SOURCE == "schedule" && $RENOVATE_TOKEN != null
+  script: renovate $RENOVATE_EXTRA_FLAG
   stage: build
   variables:
     LOG_LEVEL: debug

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "config:best-practices",
+        ":maintainLockFilesWeekly"
+    ],
+    "ignorePaths": [
+        "**/template/**"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -45,6 +45,7 @@
     "pyproject",
     "pytest",
     "Quickstart",
+    "renovatebot",
     "setuptools",
     "softprops",
     "sphinxcontrib",

--- a/template/.renovaterc.json
+++ b/template/.renovaterc.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "config:best-practices",
+        ":maintainLockFilesWeekly"
+    ],
+    "ignorePaths": [
+        "**/template/**"
+    ]
+}

--- a/template/.renovaterc.json.jinja
+++ b/template/.renovaterc.json.jinja
@@ -3,8 +3,10 @@
     "extends": [
         "config:best-practices",
         ":maintainLockFilesWeekly"
-    ],
+    ]
+[%- if project_name == "Serious Scaffold Python" %],
     "ignorePaths": [
         "**/template/**"
     ]
+[%- endif %]
 }

--- a/template/.vscode/settings.json
+++ b/template/.vscode/settings.json
@@ -45,6 +45,7 @@
     "pyproject",
     "pytest",
     "Quickstart",
+    "renovatebot",
     "setuptools",
     "softprops",
     "sphinxcontrib",

--- a/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/renovate.yml.jinja
+++ b/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/renovate.yml.jinja
@@ -1,0 +1,29 @@
+name: Renovate
+jobs:
+  renovate:
+    container:
+      env:
+        LOG_LEVEL: debug
+        RENOVATE_BRANCH_PREFIX: renovate-github/
+        RENOVATE_ENABLED_MANAGERS: '["pep621", "github-actions"]'
+        RENOVATE_GIT_AUTHOR: Renovate GitHub Bot <github@renovatebot.com>
+        RENOVATE_OPTIMIZE_FOR_DISABLED: 'true'
+        RENOVATE_PLATFORM: github
+        RENOVATE_REPOSITORIES: '["{{ '${{ github.repository }}' }}"]'
+        RENOVATE_REPOSITORY_CACHE: enabled
+        RENOVATE_TOKEN: {{ '${{ secrets.RENOVATE_TOKEN }}' }}
+      image: ghcr.io/renovatebot/renovate:37.202.2
+    runs-on: ubuntu-latest
+    steps:
+      - run: env | sort
+      - run: |
+          if [ -z "{{ '${{ secrets.RENOVATE_TOKEN }}' }}" ]; then
+            echo "RENOVATE_TOKEN not set, skipping ..."
+          else
+            renovate $RENOVATE_EXTRA_FLAG
+          fi
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron: '0 * * * 0,6'
+  workflow_dispatch: null

--- a/template/[% if repo_host_type == 'gitlab.com' or repo_host_type == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/ci.yml.jinja
+++ b/template/[% if repo_host_type == 'gitlab.com' or repo_host_type == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/ci.yml.jinja
@@ -27,7 +27,7 @@ ci:
           - '3.12'
 [%- endif %]
   rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push"
     - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
   script:
     - make dev

--- a/template/[% if repo_host_type == 'gitlab.com' or repo_host_type == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/commitlint.yml
+++ b/template/[% if repo_host_type == 'gitlab.com' or repo_host_type == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/commitlint.yml
@@ -4,7 +4,7 @@ commitlint:
     entrypoint: [""]
   interruptible: true
   rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push"
     - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
   script:
     - |

--- a/template/[% if repo_host_type == 'gitlab.com' or repo_host_type == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/devcontainer.yml.jinja
+++ b/template/[% if repo_host_type == 'gitlab.com' or repo_host_type == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/devcontainer.yml.jinja
@@ -22,7 +22,8 @@ dev-container-publish:
   rules:
     - changes:
         - .devcontainer/Dockerfile
-      if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+      if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "web"
   script:
     - docker login -u ${CI_REGISTRY_USER} -p ${CI_REGISTRY_PASSWORD} ${CI_REGISTRY}
     - docker context create builder

--- a/template/[% if repo_host_type == 'gitlab.com' or repo_host_type == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/renovate.yml
+++ b/template/[% if repo_host_type == 'gitlab.com' or repo_host_type == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/renovate.yml
@@ -1,0 +1,27 @@
+renovate:
+  cache:
+    key: ${CI_COMMIT_REF_SLUG}-renovate
+    paths:
+      - renovate/cache/renovate/repository/
+  image: renovate/renovate:37.202.2
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+  script:
+    - |
+      if [ -z "$RENOVATE_TOKEN" ]; then
+        echo "RENOVATE_TOKEN not set, skipping ..."
+      else
+        renovate $RENOVATE_EXTRA_FLAG
+      fi
+  stage: build
+  variables:
+    LOG_LEVEL: debug
+    RENOVATE_BASE_DIR: $CI_PROJECT_DIR/renovate
+    RENOVATE_BRANCH_PREFIX: renovate-gitlab/
+    RENOVATE_ENABLED_MANAGERS: '["pep621"]'
+    RENOVATE_ENDPOINT: $CI_API_V4_URL
+    RENOVATE_GIT_AUTHOR: Renovate GitLab Bot <gitlab@renovatebot.com>
+    RENOVATE_OPTIMIZE_FOR_DISABLED: 'true'
+    RENOVATE_PLATFORM: gitlab
+    RENOVATE_REPOSITORIES: '["$CI_PROJECT_PATH"]'
+    RENOVATE_REPOSITORY_CACHE: enabled

--- a/template/[% if repo_host_type == 'gitlab.com' or repo_host_type == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/renovate.yml
+++ b/template/[% if repo_host_type == 'gitlab.com' or repo_host_type == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/renovate.yml
@@ -5,14 +5,8 @@ renovate:
       - renovate/cache/renovate/repository/
   image: renovate/renovate:37.202.2
   rules:
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-  script:
-    - |
-      if [ -z "$RENOVATE_TOKEN" ]; then
-        echo "RENOVATE_TOKEN not set, skipping ..."
-      else
-        renovate $RENOVATE_EXTRA_FLAG
-      fi
+    - if: $CI_PIPELINE_SOURCE == "schedule" && $RENOVATE_TOKEN != null
+  script: renovate $RENOVATE_EXTRA_FLAG
   stage: build
   variables:
     LOG_LEVEL: debug


### PR DESCRIPTION
An expected result can be found here: 
- https://github.com/huxuan/ss-python/issues/5
- https://gitlab.com/huxuan8528/ss-python/-/issues/1

Note that only `pep621` (for GitHub and GitLab) and `github-actions` (for GitHub only) managers are enabled as others needs further configuration. 


<!-- readthedocs-preview ss-python start -->
----
📚 Documentation preview 📚: https://ss-python--321.org.readthedocs.build/en/321/

<!-- readthedocs-preview ss-python end -->