### PR TITLE
chore: authenticate renovate with github app when configured

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -13,12 +13,22 @@ jobs:
         RENOVATE_REPOSITORY_CACHE: enabled
         RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN }}
       image: ghcr.io/renovatebot/renovate:37.202.2
+      options: '--user root'
     runs-on: ubuntu-latest
     steps:
       - run: env | sort
-      - run: |
-          if [ -z "${{ secrets.RENOVATE_TOKEN }}" ]; then
-            echo "RENOVATE_TOKEN not set, skipping ..."
+      - id: generate-token
+        name: Generate a token with GitHub App if App ID exists
+        if: vars.BOT_APP_ID
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
+      - env:
+          RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN || steps.generate-token.outputs.token }}
+        run: |
+          if [ -z "$RENOVATE_TOKEN" ]; then
+            echo "RENOVATE_TOKEN is not properly configured, skipping ..."
           else
             renovate $RENOVATE_EXTRA_FLAG
           fi

--- a/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/renovate.yml.jinja
+++ b/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/renovate.yml.jinja
@@ -13,12 +13,22 @@ jobs:
         RENOVATE_REPOSITORY_CACHE: enabled
         RENOVATE_TOKEN: {{ '${{ secrets.RENOVATE_TOKEN }}' }}
       image: ghcr.io/renovatebot/renovate:37.202.2
+      options: '--user root'
     runs-on: ubuntu-latest
     steps:
       - run: env | sort
-      - run: |
-          if [ -z "{{ '${{ secrets.RENOVATE_TOKEN }}' }}" ]; then
-            echo "RENOVATE_TOKEN not set, skipping ..."
+      - id: generate-token
+        name: Generate a token with GitHub App if App ID exists
+        if: vars.BOT_APP_ID
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: {{ '${{ vars.BOT_APP_ID }}' }}
+          private-key: {{ '${{ secrets.BOT_PRIVATE_KEY }}' }}
+      - env:
+          RENOVATE_TOKEN: {{ '${{ secrets.RENOVATE_TOKEN || steps.generate-token.outputs.token }}' }}
+        run: |
+          if [ -z "$RENOVATE_TOKEN" ]; then
+            echo "RENOVATE_TOKEN is not properly configured, skipping ..."
           else
             renovate $RENOVATE_EXTRA_FLAG
           fi


### PR DESCRIPTION
Expected workflow run: 
  - PAT directly as RENOVATE_TOKEN: https://github.com/huxuan/ss-python/actions/runs/8014762535/job/21893880462 
  - Generate token with GitHub App: <del>https://github.com/huxuan/ss-python/actions/runs/8014581681/job/21893417864</del>https://github.com/huxuan/ss-python/actions/runs/8014602038/job/21893474172

Expected pull requests when using GitHub App:
  - https://github.com/huxuan/ss-python/pull/6
  - https://github.com/huxuan/ss-python/pull/7

<!-- readthedocs-preview ss-python start -->
----
📚 Documentation preview 📚: https://ss-python--327.org.readthedocs.build/en/327/

<!-- readthedocs-preview ss-python end -->