### PR TITLE
chore: sync renovate cron with preset 'maintainLockFilesWeekly'

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -35,5 +35,5 @@ jobs:
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron: '0 * * * 0,6'
+    - cron: '*/15 0-3 * * 1'
   workflow_dispatch: null

--- a/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/renovate.yml.jinja
+++ b/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/renovate.yml.jinja
@@ -35,5 +35,5 @@ jobs:
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron: '0 * * * 0,6'
+    - cron: '*/15 0-3 * * 1'
   workflow_dispatch: null


### PR DESCRIPTION
The [default schedule](https://docs.renovatebot.com/configuration-options/#lockfilemaintenance) for [maintainlockfilesweekly](https://docs.renovatebot.com/presets-default/#maintainlockfilesweekly) is `before 4am on monday` which looks to be a good convention to follow.