### PR TITLE
chore: config gitlabci manager for renovate

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -5,7 +5,7 @@ jobs:
       env:
         LOG_LEVEL: debug
         RENOVATE_BRANCH_PREFIX: renovate-github/
-        RENOVATE_ENABLED_MANAGERS: '["pep621", "github-actions"]'
+        RENOVATE_ENABLED_MANAGERS: '["pep621", "github-actions", "gitlabci"]'
         RENOVATE_GIT_AUTHOR: Renovate GitHub Bot <github@renovatebot.com>
         RENOVATE_OPTIMIZE_FOR_DISABLED: 'true'
         RENOVATE_PLATFORM: github

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -9,6 +9,7 @@ jobs:
         RENOVATE_GIT_AUTHOR: Renovate GitHub Bot <github@renovatebot.com>
         RENOVATE_OPTIMIZE_FOR_DISABLED: 'true'
         RENOVATE_PLATFORM: github
+        RENOVATE_PR_HOURLY_LIMIT: 0
         RENOVATE_REPOSITORIES: '["${{ github.repository }}"]'
         RENOVATE_REPOSITORY_CACHE: enabled
         RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -9,7 +9,6 @@ jobs:
         RENOVATE_GIT_AUTHOR: Renovate GitHub Bot <github@renovatebot.com>
         RENOVATE_OPTIMIZE_FOR_DISABLED: 'true'
         RENOVATE_PLATFORM: github
-        RENOVATE_PR_HOURLY_LIMIT: 0
         RENOVATE_REPOSITORIES: '["${{ github.repository }}"]'
         RENOVATE_REPOSITORY_CACHE: enabled
         RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN }}

--- a/.gitlab/workflows/renovate.yml
+++ b/.gitlab/workflows/renovate.yml
@@ -12,7 +12,7 @@ renovate:
     LOG_LEVEL: debug
     RENOVATE_BASE_DIR: $CI_PROJECT_DIR/renovate
     RENOVATE_BRANCH_PREFIX: renovate-gitlab/
-    RENOVATE_ENABLED_MANAGERS: '["pep621"]'
+    RENOVATE_ENABLED_MANAGERS: '["pep621", "gitlabci"]'
     RENOVATE_ENDPOINT: $CI_API_V4_URL
     RENOVATE_GIT_AUTHOR: Renovate GitLab Bot <gitlab@renovatebot.com>
     RENOVATE_OPTIMIZE_FOR_DISABLED: 'true'

--- a/.gitlab/workflows/renovate.yml
+++ b/.gitlab/workflows/renovate.yml
@@ -17,5 +17,6 @@ renovate:
     RENOVATE_GIT_AUTHOR: Renovate GitLab Bot <gitlab@renovatebot.com>
     RENOVATE_OPTIMIZE_FOR_DISABLED: 'true'
     RENOVATE_PLATFORM: gitlab
+    RENOVATE_PR_HOURLY_LIMIT: 0
     RENOVATE_REPOSITORIES: '["$CI_PROJECT_PATH"]'
     RENOVATE_REPOSITORY_CACHE: enabled

--- a/.gitlab/workflows/renovate.yml
+++ b/.gitlab/workflows/renovate.yml
@@ -17,6 +17,5 @@ renovate:
     RENOVATE_GIT_AUTHOR: Renovate GitLab Bot <gitlab@renovatebot.com>
     RENOVATE_OPTIMIZE_FOR_DISABLED: 'true'
     RENOVATE_PLATFORM: gitlab
-    RENOVATE_PR_HOURLY_LIMIT: 0
     RENOVATE_REPOSITORIES: '["$CI_PROJECT_PATH"]'
     RENOVATE_REPOSITORY_CACHE: enabled

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -4,6 +4,11 @@
         "config:best-practices",
         ":maintainLockFilesWeekly"
     ],
+    "gitlabci": {
+        "fileMatch": [
+            "^.gitlab/workflows/.*\\.yml$"
+        ]
+    },
     "ignorePaths": [
         "**/template/**"
     ]

--- a/template/.renovaterc.json.jinja
+++ b/template/.renovaterc.json.jinja
@@ -4,6 +4,13 @@
         "config:best-practices",
         ":maintainLockFilesWeekly"
     ]
+[%- if repo_host_type == "gitlab.com" or reop_host_type == "gitlab-self-managed" or project_name == "Serious Scaffold Python" %],
+    "gitlabci": {
+        "fileMatch": [
+            "^.gitlab/workflows/.*\\.yml$"
+        ]
+    }
+[%- endif %]
 [%- if project_name == "Serious Scaffold Python" %],
     "ignorePaths": [
         "**/template/**"

--- a/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/renovate.yml.jinja
+++ b/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/renovate.yml.jinja
@@ -5,7 +5,11 @@ jobs:
       env:
         LOG_LEVEL: debug
         RENOVATE_BRANCH_PREFIX: renovate-github/
+[%- if project_name == "Serious Scaffold Python" %]
+        RENOVATE_ENABLED_MANAGERS: '["pep621", "github-actions", "gitlabci"]'
+[%- else -%]
         RENOVATE_ENABLED_MANAGERS: '["pep621", "github-actions"]'
+[%- endif %]
         RENOVATE_GIT_AUTHOR: Renovate GitHub Bot <github@renovatebot.com>
         RENOVATE_OPTIMIZE_FOR_DISABLED: 'true'
         RENOVATE_PLATFORM: github

--- a/template/[% if repo_host_type == 'gitlab.com' or repo_host_type == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/renovate.yml
+++ b/template/[% if repo_host_type == 'gitlab.com' or repo_host_type == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/renovate.yml
@@ -12,7 +12,7 @@ renovate:
     LOG_LEVEL: debug
     RENOVATE_BASE_DIR: $CI_PROJECT_DIR/renovate
     RENOVATE_BRANCH_PREFIX: renovate-gitlab/
-    RENOVATE_ENABLED_MANAGERS: '["pep621"]'
+    RENOVATE_ENABLED_MANAGERS: '["pep621", "gitlabci"]'
     RENOVATE_ENDPOINT: $CI_API_V4_URL
     RENOVATE_GIT_AUTHOR: Renovate GitLab Bot <gitlab@renovatebot.com>
     RENOVATE_OPTIMIZE_FOR_DISABLED: 'true'


### PR DESCRIPTION
With this pull request, we should generate the `.renovaterc.json` for end users which only update those generated files.

<!-- readthedocs-preview ss-python start -->
----
📚 Documentation preview 📚: https://ss-python--340.org.readthedocs.build/en/340/

<!-- readthedocs-preview ss-python end -->