### PR TITLE
docs: avoid line too long problem when the project name is long

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,8 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 templates_path = ["_templates"]
 html_theme_options = {
     "announcement": (
-        "<em>Serious Scaffold Python</em> is in the <strong>Alpha</strong> phase. "
+        "<em>Serious Scaffold Python</em> "
+        "is in the <strong>Alpha</strong> phase. "
         "Frequent changes and instability should be anticipated. "
         "Any feedback, comments, suggestions and contributions are welcome!"
     ),

--- a/template/docs/conf.py.jinja
+++ b/template/docs/conf.py.jinja
@@ -37,7 +37,8 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 templates_path = ["_templates"]
 html_theme_options = {
     "announcement": (
-        "<em>{{ project_name }}</em> is in the <strong>{{ development_status }}</strong> phase. "
+        "<em>{{ project_name }}</em> "
+        "is in the <strong>{{ development_status }}</strong> phase. "
 [%- if development_status == "Alpha" %]
         "Frequent changes and instability should be anticipated. "
 [%- elif development_status == "Beta" %]


### PR DESCRIPTION


<!-- readthedocs-preview ss-python start -->
----
📚 Documentation preview 📚: https://ss-python--341.org.readthedocs.build/en/341/

<!-- readthedocs-preview ss-python end -->