### PR TITLE
chore: separate specific data file and default value

### DIFF
--- a/.copier-data.yml
+++ b/.copier-data.yml
@@ -1,0 +1,19 @@
+author_email: i@huxuan.org
+author_name: huxuan
+copyright_holder: Serious Scaffold
+copyright_license: MIT License
+copyright_year: 2022-2024
+coverage_threshold: 100
+default_py: '3.12'
+development_status: Alpha
+max_py: '3.12'
+min_py: '3.8'
+module_name: ss_python
+organization_name: Serious Scaffold
+package_name: ss-python
+project_description: A Python project template covering the entire development lifecycle
+    with various integrations, configurations and modules.
+project_name: Serious Scaffold Python
+repo_host_type: github.com
+repo_name: ss-python
+repo_namespace: serious-scaffold

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,13 +47,7 @@ jobs:
       - run: env | sort
       - name: Install copier for template rendering using pipx
         run: pipx install copier
-      - name: Generate the project with the default value
-        run: |
-          find . -maxdepth 1 | grep -vE '(\.|\.git|\.copier-data\.yml|template|includes|copier\.yaml|pdm\.lock)$' | xargs -I {} rm -r {}
-          copier copy --data-file .copier-data.yml --vcs-ref HEAD --force --data repo_host_type=gitlab.com . .
-          rm .copier-answers.yml
-          copier copy --data-file .copier-data.yml --vcs-ref HEAD --force . .
-          rm .copier-answers.yml
+      - run: make consistency
       - run: git diff
       - run: git status --porcelain
       - run: test -z "$(git status --porcelain)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,10 @@ jobs:
         run: pipx install copier
       - name: Generate the project with the default value
         run: |
-          find . -maxdepth 1 | grep -vE '(\.|template|includes|\.git|copier\.yaml|pdm\.lock)$' | xargs -I {} rm -r {}
-          copier copy -d repo_host_type=gitlab.com -r HEAD -f . .
+          find . -maxdepth 1 | grep -vE '(\.|\.git|\.copier-data\.yml|template|includes|copier\.yaml|pdm\.lock)$' | xargs -I {} rm -r {}
+          copier copy --data-file .copier-data.yml --vcs-ref HEAD --force --data repo_host_type=gitlab.com . .
           rm .copier-answers.yml
+          copier copy --data-file .copier-data.yml --vcs-ref HEAD --force . .
           copier copy -r HEAD -f . .
           rm .copier-answers.yml
       - run: git diff

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,6 @@ jobs:
           copier copy --data-file .copier-data.yml --vcs-ref HEAD --force --data repo_host_type=gitlab.com . .
           rm .copier-answers.yml
           copier copy --data-file .copier-data.yml --vcs-ref HEAD --force . .
-          copier copy -r HEAD -f . .
           rm .copier-answers.yml
       - run: git diff
       - run: git status --porcelain

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean deepclean install dev mypy ruff ruff-format toml-sort lint pre-commit test-run test build publish doc-autobuild changelog doc-gen doc-mypy doc-coverage doc
+.PHONY: clean deepclean install dev mypy ruff ruff-format toml-sort lint pre-commit test-run test build publish doc-autobuild changelog doc-gen doc-mypy doc-coverage doc consistency
 
 ########################################################################################
 # Variables
@@ -22,7 +22,6 @@ CHANGELOG_PATH := docs/changelog.md
 clean:
 	-rm -rf \
 		$(PUBLIC_DIR) \
-		.copier-answers.yml \
 		.coverage \
 		.mypy_cache \
 		.pdm-build \
@@ -151,6 +150,17 @@ doc-coverage: test-run doc-gen
 
 # Generate all documentation with reports.
 doc: changelog doc-gen doc-mypy doc-coverage
+
+########################################################################################
+# Template
+########################################################################################
+
+consistency:
+	find . -maxdepth 1 | grep -vE '(\.|\.git|\.copier-data\.yml|template|includes|copier\.yaml|pdm\.lock)$$' | xargs -I {} rm -r {}
+	copier copy -r HEAD --data-file .copier-data.yml --data repo_host_type=gitlab.com -f . .
+	rm -rf .copier-answers.yml
+	copier copy -r HEAD --data-file .copier-data.yml -f . .
+	rm -rf .copier-answers.yml
 
 ########################################################################################
 # End

--- a/copier.yaml
+++ b/copier.yaml
@@ -19,11 +19,11 @@ _message_after_update: |
   In case there are any conflicts, please resolve them. Then,
   you're done.
 project_name:
-  default: Serious Scaffold Python
+  default: My Project
   help: 'Enter the name of the project in CamelCase format:'
   type: str
 project_description:
-  default: A Python project template covering the entire development lifecycle with various integrations, configurations and modules.
+  default: A brief description of my project.
   help: 'Provide a brief description for the project:'
   type: str
 development_status:
@@ -52,11 +52,11 @@ copyright_year:
   help: Enter the copyright year or range (e.g. "2022-2023").
   type: str
 author_name:
-  default: huxuan
+  default: Your Name
   help: 'Specify the name of the author:'
   type: str
 organization_name:
-  default: Serious Scaffold
+  default: Your Organization Name
   help: 'Provide the name of the organization associated with the project:'
   type: str
 copyright_holder:
@@ -64,12 +64,7 @@ copyright_holder:
   help: Name(s) or organization(s) holding the copyright.
   type: str
 author_email:
-  default: |-
-    [% if author_name == 'huxuan' and organization_name == 'Serious Scaffold' -%]
-      i@huxuan.org
-    [%- else -%]
-      {{ author_name }}@{{ organization_name|lower|replace(" ", "-") }}.com
-    [%- endif %]
+  default: '{{ author_name|lower|replace(" ", ".") }}@{{ organization_name|lower|replace(" ", "-") }}.com'
   help: 'Specify the email address of the author:'
   type: str
 repo_host_type:
@@ -110,21 +105,11 @@ repo_namespace:
   help: 'Indicate the GitHub Repository Owner or GitLab Namespace. This is typically the account name of the author or the organization:'
   type: str
 repo_name:
-  default: |-
-    [% if project_name == 'Serious Scaffold Python' -%]
-      ss-python
-    [%- else -%]
-      {{ project_name|lower|replace(" ", "-") }}
-    [%- endif %]
+  default: '{{ project_name|lower|replace(" ", "-") }}'
   help: 'Provide a name for the repository:'
   type: str
 package_name:
-  default: |-
-    [% if project_name == 'Serious Scaffold Python' -%]
-      {{ repo_name }}
-    [%- else -%]
-      {{ repo_name|regex_replace("-python$", "") }}
-    [%- endif %]
+  default: '{{ repo_name|regex_replace("-python$", "") }}'
   help: 'Specify the name of the distributable package for the project (often used in "pip install <package_name>"):'
   type: str
 module_name:

--- a/template/Makefile.jinja
+++ b/template/Makefile.jinja
@@ -1,5 +1,6 @@
 [% from pathjoin("includes", "variable.jinja") import page_url with context -%]
 .PHONY: clean deepclean install dev mypy ruff ruff-format toml-sort lint pre-commit test-run test build publish doc-autobuild changelog doc-gen doc-mypy doc-coverage doc
+[%- if project_name == "Serious Scaffold Python" %] consistency[% endif %]
 
 ########################################################################################
 # Variables
@@ -23,9 +24,6 @@ CHANGELOG_PATH := docs/changelog.md
 clean:
 	-rm -rf \
 		$(PUBLIC_DIR) \
-[%- if project_name == "Serious Scaffold Python" %]
-		.copier-answers.yml \
-[%- endif %]
 		.coverage \
 		.mypy_cache \
 		.pdm-build \
@@ -155,6 +153,19 @@ doc-coverage: test-run doc-gen
 # Generate all documentation with reports.
 doc: changelog doc-gen doc-mypy doc-coverage
 
+[% if project_name == "Serious Scaffold Python" -%]
+########################################################################################
+# Template
+########################################################################################
+
+consistency:
+	find . -maxdepth 1 | grep -vE '(\.|\.git|\.copier-data\.yml|template|includes|copier\.yaml|pdm\.lock)$$' | xargs -I {} rm -r {}
+	copier copy -r HEAD --data-file .copier-data.yml --data repo_host_type=gitlab.com -f . .
+	rm -rf .copier-answers.yml
+	copier copy -r HEAD --data-file .copier-data.yml -f . .
+	rm -rf .copier-answers.yml
+
+[% endif -%]
 ########################################################################################
 # End
 ########################################################################################

--- a/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/ci.yml.jinja
+++ b/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/ci.yml.jinja
@@ -59,13 +59,7 @@ jobs:
       - run: env | sort
       - name: Install copier for template rendering using pipx
         run: pipx install copier
-      - name: Generate the project with the default value
-        run: |
-          find . -maxdepth 1 | grep -vE '(\.|\.git|\.copier-data\.yml|template|includes|copier\.yaml|pdm\.lock)$' | xargs -I {} rm -r {}
-          copier copy --data-file .copier-data.yml --vcs-ref HEAD --force --data repo_host_type=gitlab.com . .
-          rm .copier-answers.yml
-          copier copy --data-file .copier-data.yml --vcs-ref HEAD --force . .
-          rm .copier-answers.yml
+      - run: make consistency
       - run: git diff
       - run: git status --porcelain
       - run: test -z "$(git status --porcelain)"

--- a/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/ci.yml.jinja
+++ b/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/ci.yml.jinja
@@ -61,10 +61,10 @@ jobs:
         run: pipx install copier
       - name: Generate the project with the default value
         run: |
-          find . -maxdepth 1 | grep -vE '(\.|template|includes|\.git|copier\.yaml|pdm\.lock)$' | xargs -I {} rm -r {}
-          copier copy -d repo_host_type=gitlab.com -r HEAD -f . .
+          find . -maxdepth 1 | grep -vE '(\.|\.git|\.copier-data\.yml|template|includes|copier\.yaml|pdm\.lock)$' | xargs -I {} rm -r {}
+          copier copy --data-file .copier-data.yml --vcs-ref HEAD --force --data repo_host_type=gitlab.com . .
           rm .copier-answers.yml
-          copier copy -r HEAD -f . .
+          copier copy --data-file .copier-data.yml --vcs-ref HEAD --force . .
           rm .copier-answers.yml
       - run: git diff
       - run: git status --porcelain


### PR DESCRIPTION
Previously, data file specific to serious-scaffold-python and template default value are mixed. Now we would like to separate them so that we can easily manage a demo project or test with different values in the future.

<!-- readthedocs-preview ss-python start -->
----
📚 Documentation preview 📚: https://ss-python--359.org.readthedocs.build/en/359/

<!-- readthedocs-preview ss-python end -->