### PR TITLE
chore: group renovate docker tags for serious-scaffold-python only

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -37,6 +37,16 @@
     },
     "packageRules": [
         {
+            "groupName": "renovate docker tag",
+            "matchDatasources": [
+                "docker"
+            ],
+            "matchDepNames": [
+                "ghcr.io/renovatebot/renovate",
+                "renovate/renovate"
+            ]
+        },
+        {
             "commitMessageTopic": "serious-scaffold-python",
             "matchDepTypes": [
                 "copier-template"

--- a/template/.renovaterc.json.jinja
+++ b/template/.renovaterc.json.jinja
@@ -31,15 +31,27 @@
     "extends": [
         "config:best-practices",
         ":maintainLockFilesWeekly"
-    ]
-[%- if repo_host_type == "gitlab.com" or reop_host_type == "gitlab-self-managed" or project_name == "Serious Scaffold Python" %],
+    ],
+[%- if repo_host_type == "gitlab.com" or reop_host_type == "gitlab-self-managed" or project_name == "Serious Scaffold Python" %]
     "gitlabci": {
         "fileMatch": [
             "^.gitlab/workflows/.*\\.yml$"
         ]
-    }
-[%- endif %],
+    },
+[%- endif %]
     "packageRules": [
+[%- if project_name == "Serious Scaffold Python" %]
+        {
+            "groupName": "renovate docker tag",
+            "matchDatasources": [
+                "docker"
+            ],
+            "matchDepNames": [
+                "ghcr.io/renovatebot/renovate",
+                "renovate/renovate"
+            ]
+        },
+[%- endif %]
         {
             "commitMessageTopic": "serious-scaffold-python",
             "matchDepTypes": [


### PR DESCRIPTION
Reduce the number of pull requests for maintenance

Expected result: https://github.com/huxuan/ss-python/pull/27

<!-- readthedocs-preview ss-python start -->
----
📚 Documentation preview 📚: https://ss-python--375.org.readthedocs.build/en/375/

<!-- readthedocs-preview ss-python end -->