### PR TITLE
chore: trigger readthedocs preview only when docs change

### DIFF
--- a/.github/workflows/readthedocs-preview.yml
+++ b/.github/workflows/readthedocs-preview.yml
@@ -13,5 +13,7 @@ on:
   pull_request_target:
     types:
       - opened
+    paths:
+      - docs/**
 permissions:
   pull-requests: write

--- a/.github/workflows/readthedocs-preview.yml
+++ b/.github/workflows/readthedocs-preview.yml
@@ -14,6 +14,7 @@ on:
     types:
       - opened
     paths:
-      - 'docs/**'
+      - docs/**
+      - README.md
 permissions:
   pull-requests: write

--- a/.github/workflows/readthedocs-preview.yml
+++ b/.github/workflows/readthedocs-preview.yml
@@ -14,6 +14,6 @@ on:
     types:
       - opened
     paths:
-      - docs/**
+      - 'docs/**'
 permissions:
   pull-requests: write

--- a/.github/workflows/readthedocs-preview.yml
+++ b/.github/workflows/readthedocs-preview.yml
@@ -14,8 +14,9 @@ on:
     types:
       - opened
     paths:
-      - docs/**
-      - README.md
+      - .github/workflows/readthedocs-preview.yml
       - .readthedocs.yaml
+      - README.md
+      - docs/**
 permissions:
   pull-requests: write

--- a/.github/workflows/readthedocs-preview.yml
+++ b/.github/workflows/readthedocs-preview.yml
@@ -16,5 +16,6 @@ on:
     paths:
       - docs/**
       - README.md
+      - .readthedocs.yaml
 permissions:
   pull-requests: write

--- a/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/readthedocs-preview.yml.jinja
+++ b/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/readthedocs-preview.yml.jinja
@@ -13,5 +13,7 @@ on:
   pull_request_target:
     types:
       - opened
+    paths:
+      - docs/**
 permissions:
   pull-requests: write

--- a/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/readthedocs-preview.yml.jinja
+++ b/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/readthedocs-preview.yml.jinja
@@ -14,6 +14,7 @@ on:
     types:
       - opened
     paths:
-      - 'docs/**'
+      - docs/**
+      - README.md
 permissions:
   pull-requests: write

--- a/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/readthedocs-preview.yml.jinja
+++ b/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/readthedocs-preview.yml.jinja
@@ -14,6 +14,6 @@ on:
     types:
       - opened
     paths:
-      - docs/**
+      - 'docs/**'
 permissions:
   pull-requests: write

--- a/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/readthedocs-preview.yml.jinja
+++ b/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/readthedocs-preview.yml.jinja
@@ -14,8 +14,9 @@ on:
     types:
       - opened
     paths:
-      - docs/**
-      - README.md
+      - .github/workflows/readthedocs-preview.yml
       - .readthedocs.yaml
+      - README.md
+      - docs/**
 permissions:
   pull-requests: write

--- a/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/readthedocs-preview.yml.jinja
+++ b/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/readthedocs-preview.yml.jinja
@@ -16,5 +16,6 @@ on:
     paths:
       - docs/**
       - README.md
+      - .readthedocs.yaml
 permissions:
   pull-requests: write


### PR DESCRIPTION
Test:
- https://github.com/huxuan/ss-python/pull/30
- https://github.com/huxuan/ss-python/pull/31
- https://github.com/huxuan/ss-python/pull/32

Actually, I am a little confused about the preview link in this pull request. Seems the changes to workflows does not take effect immediately. Let me know if I made anything wrong.

<!-- readthedocs-preview ss-python start -->
----
📚 Documentation preview 📚: https://ss-python--377.org.readthedocs.build/en/377/

<!-- readthedocs-preview ss-python end -->