### PR TITLE
chore: support RENOVATE_ENABLED in GitHub Actions

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -6,6 +6,7 @@ jobs:
         LOG_LEVEL: debug
         RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS: '["^git", "^pip", "^copier"]'
         RENOVATE_BRANCH_PREFIX: renovate-github/
+        RENOVATE_ENABLED: ${{ vars.RENOVATE_ENABLED || true }}
         RENOVATE_ENABLED_MANAGERS: '["pep621", "github-actions", "gitlabci", "regex"]'
         RENOVATE_GIT_AUTHOR: Renovate GitHub Bot <github@renovatebot.com>
         RENOVATE_OPTIMIZE_FOR_DISABLED: 'true'

--- a/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/renovate.yml.jinja
+++ b/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/renovate.yml.jinja
@@ -6,6 +6,7 @@ jobs:
         LOG_LEVEL: debug
         RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS: '["^git", "^pip", "^copier"]'
         RENOVATE_BRANCH_PREFIX: renovate-github/
+        RENOVATE_ENABLED: {{ '${{ vars.RENOVATE_ENABLED || true }}' }}
 [%- if project_name == "Serious Scaffold Python" %]
         RENOVATE_ENABLED_MANAGERS: '["pep621", "github-actions", "gitlabci", "regex"]'
 [%- else -%]


### PR DESCRIPTION
Unlike GitLab CI/CD, containerized GitHub Action jobs need to specify the mapping of environment variables.

Ref: https://docs.github.com/en/actions/using-jobs/running-jobs-in-a-container#using-environment-variables-with-a-container

<!-- readthedocs-preview ss-python start -->
----
📚 Documentation preview 📚: https://ss-python--387.org.readthedocs.build/en/387/

<!-- readthedocs-preview ss-python end -->