### PR TITLE
chore: fix commitlint GIT_STRATEGY in GitLab CI/CD

### DIFF
--- a/.gitlab/workflows/commitlint.yml
+++ b/.gitlab/workflows/commitlint.yml
@@ -14,5 +14,3 @@ commitlint:
         echo "$CI_MERGE_REQUEST_TITLE" | commitlint
       fi
   stage: ci
-  variables:
-    GIT_STRATEGY: none

--- a/template/[% if repo_host_type == 'gitlab.com' or repo_host_type == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/commitlint.yml
+++ b/template/[% if repo_host_type == 'gitlab.com' or repo_host_type == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/commitlint.yml
@@ -14,5 +14,3 @@ commitlint:
         echo "$CI_MERGE_REQUEST_TITLE" | commitlint
       fi
   stage: ci
-  variables:
-    GIT_STRATEGY: none


### PR DESCRIPTION
Commitlint needs configuration to run, which is included in the source code.

https://gitlab.com/huxuan8528/ss-python/-/jobs/6360858768

Sorry for the introduced bug. :-(