### PR TITLE
chore: fix typo in matchDepTypes in renovate configuration

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -82,8 +82,8 @@
         {
             "matchDepTypes": [
                 "container",
-                "docker",
                 "image",
+                "image-name",
                 "service-image"
             ],
             "postUpgradeTasks": {

--- a/template/.renovaterc.json.jinja
+++ b/template/.renovaterc.json.jinja
@@ -90,8 +90,8 @@
         {
             "matchDepTypes": [
                 "container",
-                "docker",
                 "image",
+                "image-name",
                 "service-image"
             ],
             "postUpgradeTasks": {


### PR DESCRIPTION
Sorry for the typo that leads to the following inconsistency error.

Failed pull request: https://github.com/serious-scaffold/ss-python/pull/395
Failed workflow: https://github.com/serious-scaffold/ss-python/actions/runs/8273933284/job/22638514452?pr=395

Fixed pull request: https://github.com/huxuan/ss-python/pull/58
Fixed workflow: https://github.com/huxuan/ss-python/actions/runs/8274060306/job/22638839560?pr=58