### PR TITLE
chore: cancel build on Read the Docs conditionally

### DIFF
--- a/.github/workflows/readthedocs-preview.yml
+++ b/.github/workflows/readthedocs-preview.yml
@@ -18,5 +18,6 @@ on:
       - .readthedocs.yaml
       - README.md
       - docs/**
+      - pdm.lock
 permissions:
   pull-requests: write

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,7 +11,7 @@ build:
       # This is a special exit code on Read the Docs that will cancel the build immediately.
       # Ref: https://docs.readthedocs.io/en/stable/build-customization.html#cancel-build-based-on-a-condition
       - |
-        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- README.md;
+        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- .github/workflows/readthedocs-preview.yml .readthedocs.yaml README.md docs/ pdm.lock;
         then
           exit 183;
         fi

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,9 +15,6 @@ build:
         then
           exit 183;
         fi
-      # Use `git log` to check if the latest commit contains "skip ci",
-      # in that case exit the command with 183 to cancel the build
-      - (git --no-pager log --pretty="tformat:%s -- %b" -1 | grep -viq "skip ci") || exit 183
     post_install:
       - python -m pip install --upgrade --no-cache-dir pdm
       - PDM_NO_EDITABLE=true make dev-doc

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,7 +11,7 @@ build:
       # This is a special exit code on Read the Docs that will cancel the build immediately.
       # Ref: https://docs.readthedocs.io/en/stable/build-customization.html#cancel-build-based-on-a-condition
       - |
-        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- .github/workflows/readthedocs-preview.yml .readthedocs.yaml README.md docs/ pdm.lock;
+        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- README.md;
         then
           exit 183;
         fi

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,6 +6,18 @@ build:
     post_checkout:
       - env | sort
       - git fetch --unshallow || true
+      # Cancel building pull requests when there aren't changed in the related files and folders.
+      # If there are no changes (git diff exits with 0) we force the command to return with 183.
+      # This is a special exit code on Read the Docs that will cancel the build immediately.
+      # Ref: https://docs.readthedocs.io/en/stable/build-customization.html#cancel-build-based-on-a-condition
+      - |
+        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- .github/workflows/readthedocs-preview.yml .readthedocs.yaml README.md docs/ pdm.lock;
+        then
+          exit 183;
+        fi
+      # Use `git log` to check if the latest commit contains "skip ci",
+      # in that case exit the command with 183 to cancel the build
+      - (git --no-pager log --pretty="tformat:%s -- %b" -1 | grep -viq "skip ci") || exit 183
     post_install:
       - python -m pip install --upgrade --no-cache-dir pdm
       - PDM_NO_EDITABLE=true make dev-doc

--- a/template/.readthedocs.yaml
+++ b/template/.readthedocs.yaml
@@ -11,7 +11,7 @@ build:
       # This is a special exit code on Read the Docs that will cancel the build immediately.
       # Ref: https://docs.readthedocs.io/en/stable/build-customization.html#cancel-build-based-on-a-condition
       - |
-        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- README.md;
+        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- .github/workflows/readthedocs-preview.yml .readthedocs.yaml README.md docs/ pdm.lock;
         then
           exit 183;
         fi

--- a/template/.readthedocs.yaml
+++ b/template/.readthedocs.yaml
@@ -15,9 +15,6 @@ build:
         then
           exit 183;
         fi
-      # Use `git log` to check if the latest commit contains "skip ci",
-      # in that case exit the command with 183 to cancel the build
-      - (git --no-pager log --pretty="tformat:%s -- %b" -1 | grep -viq "skip ci") || exit 183
     post_install:
       - python -m pip install --upgrade --no-cache-dir pdm
       - PDM_NO_EDITABLE=true make dev-doc

--- a/template/.readthedocs.yaml
+++ b/template/.readthedocs.yaml
@@ -11,7 +11,7 @@ build:
       # This is a special exit code on Read the Docs that will cancel the build immediately.
       # Ref: https://docs.readthedocs.io/en/stable/build-customization.html#cancel-build-based-on-a-condition
       - |
-        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- .github/workflows/readthedocs-preview.yml .readthedocs.yaml README.md docs/ pdm.lock;
+        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- README.md;
         then
           exit 183;
         fi

--- a/template/.readthedocs.yaml
+++ b/template/.readthedocs.yaml
@@ -6,6 +6,18 @@ build:
     post_checkout:
       - env | sort
       - git fetch --unshallow || true
+      # Cancel building pull requests when there aren't changed in the related files and folders.
+      # If there are no changes (git diff exits with 0) we force the command to return with 183.
+      # This is a special exit code on Read the Docs that will cancel the build immediately.
+      # Ref: https://docs.readthedocs.io/en/stable/build-customization.html#cancel-build-based-on-a-condition
+      - |
+        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- .github/workflows/readthedocs-preview.yml .readthedocs.yaml README.md docs/ pdm.lock;
+        then
+          exit 183;
+        fi
+      # Use `git log` to check if the latest commit contains "skip ci",
+      # in that case exit the command with 183 to cancel the build
+      - (git --no-pager log --pretty="tformat:%s -- %b" -1 | grep -viq "skip ci") || exit 183
     post_install:
       - python -m pip install --upgrade --no-cache-dir pdm
       - PDM_NO_EDITABLE=true make dev-doc

--- a/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/readthedocs-preview.yml.jinja
+++ b/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/readthedocs-preview.yml.jinja
@@ -18,5 +18,6 @@ on:
       - .readthedocs.yaml
       - README.md
       - docs/**
+      - pdm.lock
 permissions:
   pull-requests: write


### PR DESCRIPTION
According to the discussion here: https://github.com/readthedocs/actions/issues/39, we prefer to disable the preview documentation build when there is no relevant changes.

Test pull requests:

- no doc related changes: https://github.com/serious-scaffold/ss-python/pull/410
- doc related changes: https://github.com/serious-scaffold/ss-python/pull/411


<!-- readthedocs-preview ss-python start -->
----
📚 Documentation preview 📚: https://ss-python--406.org.readthedocs.build/en/406/

<!-- readthedocs-preview ss-python end -->