### PR TITLE
chore: set Github App as renovate git author when applicable

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -27,7 +27,7 @@ jobs:
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
       - env:
           RENOVATE_GIT_AUTHOR: ${{ steps.app-token.outputs.app-slug && format('{0}[bot] <{0}[bot]@users.noreply.github.com>', steps.app-token.outputs.app-slug) || 'Renovate GitHub Bot <github@renovatebot.com>' }}
-          RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN || steps.app-token.outputs.token }}
+          RENOVATE_TOKEN: ${{ steps.app-token.outputs.token || secrets.RENOVATE_TOKEN }}
         run: |
           if [ -z "$RENOVATE_TOKEN" ]; then
             echo "RENOVATE_TOKEN is not properly configured, skipping ..."

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -8,18 +8,17 @@ jobs:
         RENOVATE_BRANCH_PREFIX: renovate-github/
         RENOVATE_ENABLED: ${{ vars.RENOVATE_ENABLED || true }}
         RENOVATE_ENABLED_MANAGERS: '["pep621", "github-actions", "gitlabci", "regex"]'
-        RENOVATE_GIT_AUTHOR: Renovate GitHub Bot <github@renovatebot.com>
-        RENOVATE_OPTIMIZE_FOR_DISABLED: 'true'
+        RENOVATE_OPTIMIZE_FOR_DISABLED: "true"
         RENOVATE_PLATFORM: github
         RENOVATE_REPOSITORIES: '["${{ github.repository }}"]'
         RENOVATE_REPOSITORY_CACHE: enabled
         RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN }}
       image: ghcr.io/renovatebot/renovate:37.246.0-full@sha256:2bbd0a3d5d92be7c56168b369dc4119840a9e341c3c09fdef9d1ac6735042c80
-      options: '--user root'
+      options: "--user root"
     runs-on: ubuntu-22.04
     steps:
       - run: env | sort
-      - id: generate-token
+      - id: app-token
         name: Generate a token with GitHub App if App ID exists
         if: vars.BOT_APP_ID
         uses: actions/create-github-app-token@f2acddfb5195534d487896a656232b016a682f3c # v1.9.0
@@ -27,7 +26,8 @@ jobs:
           app-id: ${{ vars.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
       - env:
-          RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN || steps.generate-token.outputs.token }}
+          RENOVATE_GIT_AUTHOR: ${{ steps.app-token.outputs.app-slug && format('{0}[bot] <{0}[bot]@users.noreply.github.com>', steps.app-token.outputs.app-slug) || 'Renovate GitHub Bot <github@renovatebot.com>' }}
+          RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN || steps.app-token.outputs.token }}
         run: |
           if [ -z "$RENOVATE_TOKEN" ]; then
             echo "RENOVATE_TOKEN is not properly configured, skipping ..."
@@ -37,5 +37,5 @@ jobs:
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron: '*/15 0-3 * * 1'
+    - cron: "*/15 0-3 * * 1"
   workflow_dispatch: null

--- a/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/renovate.yml.jinja
+++ b/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/renovate.yml.jinja
@@ -12,18 +12,17 @@ jobs:
 [%- else -%]
         RENOVATE_ENABLED_MANAGERS: '["pep621", "github-actions", "regex"]'
 [%- endif %]
-        RENOVATE_GIT_AUTHOR: Renovate GitHub Bot <github@renovatebot.com>
-        RENOVATE_OPTIMIZE_FOR_DISABLED: 'true'
+        RENOVATE_OPTIMIZE_FOR_DISABLED: "true"
         RENOVATE_PLATFORM: github
         RENOVATE_REPOSITORIES: '["{{ '${{ github.repository }}' }}"]'
         RENOVATE_REPOSITORY_CACHE: enabled
         RENOVATE_TOKEN: {{ '${{ secrets.RENOVATE_TOKEN }}' }}
       image: ghcr.io/renovatebot/renovate:37.246.0-full@sha256:2bbd0a3d5d92be7c56168b369dc4119840a9e341c3c09fdef9d1ac6735042c80
-      options: '--user root'
+      options: "--user root"
     runs-on: ubuntu-22.04
     steps:
       - run: env | sort
-      - id: generate-token
+      - id: app-token
         name: Generate a token with GitHub App if App ID exists
         if: vars.BOT_APP_ID
         uses: actions/create-github-app-token@f2acddfb5195534d487896a656232b016a682f3c # v1.9.0
@@ -31,7 +30,8 @@ jobs:
           app-id: {{ '${{ vars.BOT_APP_ID }}' }}
           private-key: {{ '${{ secrets.BOT_PRIVATE_KEY }}' }}
       - env:
-          RENOVATE_TOKEN: {{ '${{ secrets.RENOVATE_TOKEN || steps.generate-token.outputs.token }}' }}
+          RENOVATE_GIT_AUTHOR: {{ '${{ steps.app-token.outputs.app-slug && format(\'{0}[bot] <{0}[bot]@users.noreply.github.com>\', steps.app-token.outputs.app-slug) || \'Renovate GitHub Bot <github@renovatebot.com>\' }}' }}
+          RENOVATE_TOKEN: {{ '${{ secrets.RENOVATE_TOKEN || steps.app-token.outputs.token }}' }}
         run: |
           if [ -z "$RENOVATE_TOKEN" ]; then
             echo "RENOVATE_TOKEN is not properly configured, skipping ..."
@@ -41,5 +41,5 @@ jobs:
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron: '*/15 0-3 * * 1'
+    - cron: "*/15 0-3 * * 1"
   workflow_dispatch: null

--- a/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/renovate.yml.jinja
+++ b/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/renovate.yml.jinja
@@ -31,7 +31,7 @@ jobs:
           private-key: {{ '${{ secrets.BOT_PRIVATE_KEY }}' }}
       - env:
           RENOVATE_GIT_AUTHOR: {{ '${{ steps.app-token.outputs.app-slug && format(\'{0}[bot] <{0}[bot]@users.noreply.github.com>\', steps.app-token.outputs.app-slug) || \'Renovate GitHub Bot <github@renovatebot.com>\' }}' }}
-          RENOVATE_TOKEN: {{ '${{ secrets.RENOVATE_TOKEN || steps.app-token.outputs.token }}' }}
+          RENOVATE_TOKEN: {{ '${{ steps.app-token.outputs.token || secrets.RENOVATE_TOKEN }}' }}
         run: |
           if [ -z "$RENOVATE_TOKEN" ]; then
             echo "RENOVATE_TOKEN is not properly configured, skipping ..."


### PR DESCRIPTION
Dependency Dashboard with corresponding pull requests for test: https://github.com/huxuan/ss-python/issues/63

Screenshot of corresponding commit:

![image](https://github.com/serious-scaffold/ss-python/assets/726061/ccc43a63-fca5-4082-9985-456c95339360)

BTW, the quotation marks are changed by GitHub Actions VSCode extension.
