### PR TITLE
chore: inject RENOVATE_GIT_AUTHOR vars in GitHub Actions

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -8,7 +8,7 @@ jobs:
         RENOVATE_BRANCH_PREFIX: renovate-github/
         RENOVATE_ENABLED: ${{ vars.RENOVATE_ENABLED || true }}
         RENOVATE_ENABLED_MANAGERS: '["pep621", "github-actions", "gitlabci", "regex"]'
-        RENOVATE_GIT_AUTHOR: Renovate GitHub Bot <github@renovatebot.com>
+        RENOVATE_GIT_AUTHOR: ${{ vars.RENOVATE_GIT_AUTHOR || 'Renovate GitHub Bot <github@renovatebot.com>' }}
         RENOVATE_OPTIMIZE_FOR_DISABLED: "true"
         RENOVATE_PLATFORM: github
         RENOVATE_REPOSITORIES: '["${{ github.repository }}"]'

--- a/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/renovate.yml.jinja
+++ b/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/renovate.yml.jinja
@@ -12,7 +12,7 @@ jobs:
 [%- else -%]
         RENOVATE_ENABLED_MANAGERS: '["pep621", "github-actions", "regex"]'
 [%- endif %]
-        RENOVATE_GIT_AUTHOR: Renovate GitHub Bot <github@renovatebot.com>
+        RENOVATE_GIT_AUTHOR: {{ '${{ vars.RENOVATE_GIT_AUTHOR || \'Renovate GitHub Bot <github@renovatebot.com>\' }}' }}
         RENOVATE_OPTIMIZE_FOR_DISABLED: "true"
         RENOVATE_PLATFORM: github
         RENOVATE_REPOSITORIES: '["{{ '${{ github.repository }}' }}"]'


### PR DESCRIPTION
For GitLab, it works natively. Please refer to: https://gitlab.com/huxuan8528/ss-python/-/merge_requests/35/commits. But it is a pity that the random string of the email address on GitLab for bot users is a must have pattern when compared with GitHub.

