### PR TITLE
perf: enable renovate to set git author when using github app token

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -8,12 +8,10 @@ jobs:
         RENOVATE_BRANCH_PREFIX: renovate-github/
         RENOVATE_ENABLED: ${{ vars.RENOVATE_ENABLED || true }}
         RENOVATE_ENABLED_MANAGERS: '["pep621", "github-actions", "gitlabci", "regex", "pre-commit"]'
-        RENOVATE_GIT_AUTHOR: ${{ vars.RENOVATE_GIT_AUTHOR || 'Renovate GitHub Bot <github@renovatebot.com>' }}
         RENOVATE_OPTIMIZE_FOR_DISABLED: "true"
         RENOVATE_PLATFORM: github
         RENOVATE_REPOSITORIES: '["${{ github.repository }}"]'
         RENOVATE_REPOSITORY_CACHE: enabled
-        RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN }}
       image: ghcr.io/renovatebot/renovate:37.269.3-full@sha256:9445e3bc58cfd9885de7c04d8b96640628a320c6022fb5928c04103196a0d09f
       options: "--user root"
     runs-on: ubuntu-22.04
@@ -27,8 +25,14 @@ jobs:
           app-id: ${{ vars.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
       - env:
-          RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN || steps.generate-token.outputs.token }}
+          RENOVATE_TOKEN: ${{ steps.generate-token.outputs.token || secrets.RENOVATE_TOKEN }}
+          RENOVATE_GIT_AUTHOR: ${{ vars.RENOVATE_GIT_AUTHOR }}
         run: |
+          if [ -n "${{ steps.generate-token.outputs.token }}" ]; then
+            unset RENOVATE_GIT_AUTHOR
+            export RENOVATE_USERNAME="${{ steps.generate-token.outputs.app-slug }}[bot]"
+          fi
+
           if [ -z "$RENOVATE_TOKEN" ]; then
             echo "RENOVATE_TOKEN is not properly configured, skipping ..."
           else

--- a/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/renovate.yml.jinja
+++ b/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/renovate.yml.jinja
@@ -12,12 +12,10 @@ jobs:
 [%- else -%]
         RENOVATE_ENABLED_MANAGERS: '["pep621", "github-actions", "regex", "pre-commit"]'
 [%- endif %]
-        RENOVATE_GIT_AUTHOR: {{ '${{ vars.RENOVATE_GIT_AUTHOR || \'Renovate GitHub Bot <github@renovatebot.com>\' }}' }}
         RENOVATE_OPTIMIZE_FOR_DISABLED: "true"
         RENOVATE_PLATFORM: github
         RENOVATE_REPOSITORIES: '["{{ '${{ github.repository }}' }}"]'
         RENOVATE_REPOSITORY_CACHE: enabled
-        RENOVATE_TOKEN: {{ '${{ secrets.RENOVATE_TOKEN }}' }}
       image: ghcr.io/renovatebot/renovate:37.269.3-full@sha256:9445e3bc58cfd9885de7c04d8b96640628a320c6022fb5928c04103196a0d09f
       options: "--user root"
     runs-on: ubuntu-22.04
@@ -31,8 +29,14 @@ jobs:
           app-id: {{ '${{ vars.BOT_APP_ID }}' }}
           private-key: {{ '${{ secrets.BOT_PRIVATE_KEY }}' }}
       - env:
-          RENOVATE_TOKEN: {{ '${{ secrets.RENOVATE_TOKEN || steps.generate-token.outputs.token }}' }}
+          RENOVATE_TOKEN: {{ '${{ steps.generate-token.outputs.token || secrets.RENOVATE_TOKEN }}' }}
+          RENOVATE_GIT_AUTHOR: {{ '${{ vars.RENOVATE_GIT_AUTHOR }}' }}
         run: |
+          if [ -n "{{ '${{ steps.generate-token.outputs.token }}' }}" ]; then
+            unset RENOVATE_GIT_AUTHOR
+            export RENOVATE_USERNAME="{{ '${{ steps.generate-token.outputs.app-slug }}' }}[bot]"
+          fi
+
           if [ -z "$RENOVATE_TOKEN" ]; then
             echo "RENOVATE_TOKEN is not properly configured, skipping ..."
           else


### PR DESCRIPTION
Refer to https://docs.renovatebot.com/modules/platform/github/#running-as-a-github-app, when using self-host renovate on github, we only need to set the RENOVATE_USERNAME.

Related #400