### PR TITLE
refactor: enhance pdm and Read the Docs integration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,6 @@ jobs:
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - run: env | sort
       - run: make dev-doc
-        env:
-          PDM_NO_EDITABLE: true
       - run: make doc
         env:
           CI_PAGES_URL: ${{ steps.pages.outputs.base_url }}

--- a/.gitlab/workflows/release.yml
+++ b/.gitlab/workflows/release.yml
@@ -7,7 +7,7 @@ pages-build:
   rules:
     - if: $CI_COMMIT_TAG =~ /^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-?(a|b|rc)(0|[1-9][0-9]*)?)?$/
   script:
-    - PDM_NO_EDITABLE=true make dev-doc
+    - make dev-doc
     - make doc
     - make release-notes > release-notes.md
   stage: release

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -26,7 +26,7 @@ build:
       - asdf install pdm 2.15.0
       - asdf global pdm 2.15.0
     post_install:
-      - make dev-doc
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH make dev-doc
     pre_build:
       - CI_PAGES_URL=https://${READTHEDOCS_PROJECT}.readthedocs.io/${READTHEDOCS_LANGUAGE}/stable make changelog
   os: ubuntu-22.04

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -23,7 +23,7 @@ build:
         fi
     post_install:
       - python -m pip install --upgrade --no-cache-dir pdm==2.15.0
-      - PDM_NO_EDITABLE=true make dev-doc
+      - make dev-doc
     pre_build:
       - CI_PAGES_URL=https://${READTHEDOCS_PROJECT}.readthedocs.io/${READTHEDOCS_LANGUAGE}/stable make changelog
   os: ubuntu-22.04

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,8 +1,5 @@
 build:
   jobs:
-    post_build:
-      - make doc-mypy
-      - make doc-coverage
     post_checkout:
       - env | sort
       - git fetch --unshallow || true
@@ -22,16 +19,24 @@ build:
           exit 183;
         fi
     pre_create_environment:
+      - env | sort
       - asdf plugin add pdm
       - asdf install pdm 2.15.0
       - asdf global pdm 2.15.0
-    pre_install:
-      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH make dev-doc
+    post_install:
+      - export VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH
+      - env | sort
+      - make dev-doc
     pre_build:
+      - env | sort
       - CI_PAGES_URL=https://${READTHEDOCS_PROJECT}.readthedocs.io/${READTHEDOCS_LANGUAGE}/stable make changelog
+    post_build:
+      - env | sort
+      - make doc-mypy
+      - make doc-coverage
   os: ubuntu-22.04
   tools:
-    python: '3'
+    python: "3"
 sphinx:
   fail_on_warning: true
 version: 2

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,6 @@
 build:
   jobs:
     post_checkout:
-      - env | sort
       - git fetch --unshallow || true
       # Cancel building pull requests when there aren't changed in the related files and folders.
       # If there are no changes (git diff exits with 0) we force the command to return with 183.
@@ -18,22 +17,18 @@ build:
         then
           exit 183;
         fi
-    pre_create_environment:
+    post_system_dependencies:
       - env | sort
+    pre_create_environment:
       - asdf plugin add pdm
       - asdf install pdm 2.15.0
       - asdf global pdm 2.15.0
     post_install:
-      - export VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH
-      - env | sort
-      - make dev-doc
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH make dev-doc
     pre_build:
-      - env | sort
-      - CI_PAGES_URL=https://${READTHEDOCS_PROJECT}.readthedocs.io/${READTHEDOCS_LANGUAGE}/stable make changelog
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH CI_PAGES_URL=https://${READTHEDOCS_PROJECT}.readthedocs.io/${READTHEDOCS_LANGUAGE}/stable make changelog
     post_build:
-      - env | sort
-      - make doc-mypy
-      - make doc-coverage
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH make doc-mypy doc-coverage
   os: ubuntu-22.04
   tools:
     python: "3"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -31,7 +31,7 @@ build:
       - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH make doc-mypy doc-coverage
   os: ubuntu-22.04
   tools:
-    python: "3"
+    python: "3.12"
 sphinx:
   fail_on_warning: true
 version: 2

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,8 +21,11 @@ build:
         then
           exit 183;
         fi
+    pre_create_environment:
+      - asdf plugin add pdm
+      - asdf install pdm 2.15.0
+      - asdf global pdm 2.15.0
     post_install:
-      - python -m pip install --upgrade --no-cache-dir pdm==2.15.0
       - make dev-doc
     pre_build:
       - CI_PAGES_URL=https://${READTHEDOCS_PROJECT}.readthedocs.io/${READTHEDOCS_LANGUAGE}/stable make changelog

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -25,7 +25,7 @@ build:
       - asdf plugin add pdm
       - asdf install pdm 2.15.0
       - asdf global pdm 2.15.0
-    post_install:
+    pre_install:
       - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH make dev-doc
     pre_build:
       - CI_PAGES_URL=https://${READTHEDOCS_PROJECT}.readthedocs.io/${READTHEDOCS_LANGUAGE}/stable make changelog

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -122,6 +122,17 @@
             }
         },
         {
+            "matchManagers": [
+                "pypi"
+            ],
+            "postUpgradeTasks": {
+                "commands": [
+                    "find template -type f -exec sed -i 's|{{{depName}}} {{{currentValue}}}|{{{depName}}} {{{newValue}}}|g' {} +",
+                    "find template -type f -exec sed -i 's|{{{depName}}}=={{{currentValue}}}|{{{depName}}}=={{{newValue}}}|g' {} +"
+                ]
+            }
+        },
+        {
             "matchDepTypes": [
                 "container",
                 "image",

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -122,7 +122,7 @@
             }
         },
         {
-            "matchManagers": [
+            "matchDatasources": [
                 "pypi"
             ],
             "postUpgradeTasks": {

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -122,17 +122,6 @@
             }
         },
         {
-            "matchDatasources": [
-                "pypi"
-            ],
-            "postUpgradeTasks": {
-                "commands": [
-                    "find template -type f -exec sed -i 's|{{{depName}}} {{{currentValue}}}|{{{depName}}} {{{newValue}}}|g' {} +",
-                    "find template -type f -exec sed -i 's|{{{depName}}}=={{{currentValue}}}|{{{depName}}}=={{{newValue}}}|g' {} +"
-                ]
-            }
-        },
-        {
             "matchDepTypes": [
                 "container",
                 "image",
@@ -142,6 +131,17 @@
             "postUpgradeTasks": {
                 "commands": [
                     "find template -type f -exec sed -i 's|{{{depName}}}:{{{currentValue}}}@{{{currentDigest}}}|{{{depName}}}:{{{newValue}}}@{{{newDigest}}}|g' {} +"
+                ]
+            }
+        },
+        {
+            "matchDatasources": [
+                "pypi"
+            ],
+            "postUpgradeTasks": {
+                "commands": [
+                    "find template -type f -exec sed -i 's|{{{depName}}} {{{currentValue}}}|{{{depName}}} {{{newValue}}}|g' {} +",
+                    "find template -type f -exec sed -i 's|{{{depName}}}=={{{currentValue}}}|{{{depName}}}=={{{newValue}}}|g' {} +"
                 ]
             }
         },

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -21,8 +21,10 @@
                 "^template/docs/.+\\.md(\\.jinja)?$"
             ],
             "matchStrings": [
-                "pipx install (?<depName>.*?)==(?<currentValue>.*?)[;\n]",
-                "pip install.* (?<depName>.*?)==(?<currentValue>.*?)[\"\n]"
+                "asdf global (?<depName>.*?) (?<currentValue>.*?)\n",
+                "asdf install (?<depName>.*?) (?<currentValue>.*?)\n",
+                "pip install.* (?<depName>.*?)==(?<currentValue>.*?)[\"\n]",
+                "pipx install (?<depName>.*?)==(?<currentValue>.*?)[;\n]"
             ]
         },
         {

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 ########################################################################################
 
 # Documentation target directory, will be adapted to specific folder for readthedocs.
-PUBLIC_DIR := $(shell [ "$$READTHEDOCS" = "True" ] && echo "$$READTHEDOCS_OUTPUT/html" || echo "public")
+PUBLIC_DIR := $(shell [ "$$READTHEDOCS" = "True" ] && echo "$${READTHEDOCS_OUTPUT}html" || echo "public")
 
 # URL and Path of changelog source code.
 CHANGELOG_URL := $(shell echo $${CI_PAGES_URL:-https://serious-scaffold.github.io/ss-python}/_sources/changelog.md.txt)
@@ -137,11 +137,11 @@ doc-gen:
 	pdm run python -m sphinx.cmd.build docs $(PUBLIC_DIR)
 
 # Generate mypy reports.
-doc-mypy: doc-gen
+doc-mypy:
 	pdm run python -m mypy src tests --html-report $(PUBLIC_DIR)/reports/mypy
 
 # Generate html coverage reports with badge.
-doc-coverage: test-run doc-gen
+doc-coverage: test-run
 	pdm run python -m coverage html -d $(PUBLIC_DIR)/reports/coverage
 	pdm run bash scripts/generate-coverage-badge.sh $(PUBLIC_DIR)/_static/badges
 

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,6 @@
 # Variables
 ########################################################################################
 
-# Global option for pdm, when in CI or readthedocs environment, no need to use venv.
-PDM_GLOBAL := $(shell [ "$$CI" = "true" ] || [ "$$READTHEDOCS" = "True" ] && echo "--global --project .")
-
 # Documentation target directory, will be adapted to specific folder for readthedocs.
 PUBLIC_DIR := $(shell [ "$$READTHEDOCS" = "True" ] && echo "$$READTHEDOCS_OUTPUT/html" || echo "public")
 
@@ -47,16 +44,16 @@ deepclean: clean
 
 # Install the package in editable mode.
 install:
-	pdm install $(PDM_GLOBAL) --prod
+	pdm install --prod
 
 # Install the package in editable mode with specific optional dependencies.
 dev-%:
-	pdm install $(PDM_GLOBAL) --dev --group $*
+	pdm install --dev --group $*
 
 # Prepare the development environment.
 # Install the pacakge in editable mode with all optional dependencies and pre-commit hoook.
 dev:
-	pdm install $(PDM_GLOBAL)
+	pdm install
 	if [ "$(CI)" != "true" ] && command -v pre-commit > /dev/null 2>&1; then pre-commit install; fi
 
 ########################################################################################
@@ -65,19 +62,19 @@ dev:
 
 # Check lint with mypy.
 mypy:
-	pdm run $(PDM_GLOBAL) python -m mypy .
+	pdm run python -m mypy .
 
 # Lint with ruff.
 ruff:
-	pdm run $(PDM_GLOBAL) python -m ruff check .
+	pdm run python -m ruff check .
 
 # Format with ruff.
 ruff-format:
-	pdm run $(PDM_GLOBAL) python -m ruff format --check .
+	pdm run python -m ruff format --check .
 
 # Check lint with toml-sort.
 toml-sort:
-	pdm run $(PDM_GLOBAL) toml-sort --check pyproject.toml
+	pdm run toml-sort --check pyproject.toml
 
 # Check lint with all linters.
 lint: mypy ruff ruff-format toml-sort
@@ -92,13 +89,13 @@ pre-commit:
 
 # Clean and run test with coverage.
 test-run:
-	pdm run $(PDM_GLOBAL) python -m coverage erase
-	pdm run $(PDM_GLOBAL) python -m coverage run -m pytest
+	pdm run python -m coverage erase
+	pdm run python -m coverage run -m pytest
 
 # Generate coverage report for terminal and xml.
 test: test-run
-	pdm run $(PDM_GLOBAL) python -m coverage report
-	pdm run $(PDM_GLOBAL) python -m coverage xml
+	pdm run python -m coverage report
+	pdm run python -m coverage xml
 
 ########################################################################################
 # Package
@@ -118,7 +115,7 @@ publish:
 
 # Generate documentation with auto build when changes happen.
 doc-autobuild:
-	pdm run $(PDM_GLOBAL) python -m sphinx_autobuild docs $(PUBLIC_DIR) \
+	pdm run python -m sphinx_autobuild docs $(PUBLIC_DIR) \
 		--watch README.md \
 		--watch src
 
@@ -129,24 +126,24 @@ changelog:
 		echo "Existing Changelog found at '$(CHANGELOG_URL)', download for incremental generation."; \
 		wget -q -O $(CHANGELOG_PATH) $(CHANGELOG_URL); \
 	fi
-	pdm run $(PDM_GLOBAL) git-changelog -ETrio $(CHANGELOG_PATH) -c conventional -s build,chore,ci,doc,feat,fix,perf,refactor,revert,style,test
+	pdm run git-changelog -ETrio $(CHANGELOG_PATH) -c conventional -s build,chore,ci,doc,feat,fix,perf,refactor,revert,style,test
 
 # Generate release notes from changelog.
 release-notes:
-	@pdm run $(PDM_GLOBAL) git-changelog --input $(CHANGELOG_PATH) --release-notes
+	@pdm run git-changelog --input $(CHANGELOG_PATH) --release-notes
 
 # Build documentation only from src.
 doc-gen:
-	pdm run $(PDM_GLOBAL) python -m sphinx.cmd.build docs $(PUBLIC_DIR)
+	pdm run python -m sphinx.cmd.build docs $(PUBLIC_DIR)
 
 # Generate mypy reports.
 doc-mypy: doc-gen
-	pdm run $(PDM_GLOBAL) python -m mypy src tests --html-report $(PUBLIC_DIR)/reports/mypy
+	pdm run python -m mypy src tests --html-report $(PUBLIC_DIR)/reports/mypy
 
 # Generate html coverage reports with badge.
 doc-coverage: test-run doc-gen
-	pdm run $(PDM_GLOBAL) python -m coverage html -d $(PUBLIC_DIR)/reports/coverage
-	pdm run $(PDM_GLOBAL) bash scripts/generate-coverage-badge.sh $(PUBLIC_DIR)/_static/badges
+	pdm run python -m coverage html -d $(PUBLIC_DIR)/reports/coverage
+	pdm run bash scripts/generate-coverage-badge.sh $(PUBLIC_DIR)/_static/badges
 
 # Generate all documentation with reports.
 doc: changelog doc-gen doc-mypy doc-coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 build-backend = "pdm.backend"
 requires = [
-  "pdm-backend",
+  "pdm-backend==2.2.1",
 ]
 
 [project]

--- a/template/.readthedocs.yaml
+++ b/template/.readthedocs.yaml
@@ -26,7 +26,7 @@ build:
       - asdf install pdm 2.15.0
       - asdf global pdm 2.15.0
     post_install:
-      - make dev-doc
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH make dev-doc
     pre_build:
       - CI_PAGES_URL=https://${READTHEDOCS_PROJECT}.readthedocs.io/${READTHEDOCS_LANGUAGE}/stable make changelog
   os: ubuntu-22.04

--- a/template/.readthedocs.yaml
+++ b/template/.readthedocs.yaml
@@ -23,7 +23,7 @@ build:
         fi
     post_install:
       - python -m pip install --upgrade --no-cache-dir pdm==2.15.0
-      - PDM_NO_EDITABLE=true make dev-doc
+      - make dev-doc
     pre_build:
       - CI_PAGES_URL=https://${READTHEDOCS_PROJECT}.readthedocs.io/${READTHEDOCS_LANGUAGE}/stable make changelog
   os: ubuntu-22.04

--- a/template/.readthedocs.yaml
+++ b/template/.readthedocs.yaml
@@ -1,10 +1,6 @@
 build:
   jobs:
-    post_build:
-      - make doc-mypy
-      - make doc-coverage
     post_checkout:
-      - env | sort
       - git fetch --unshallow || true
       # Cancel building pull requests when there aren't changed in the related files and folders.
       # If there are no changes (git diff exits with 0) we force the command to return with 183.
@@ -21,17 +17,21 @@ build:
         then
           exit 183;
         fi
+    post_system_dependencies:
+      - env | sort
     pre_create_environment:
       - asdf plugin add pdm
       - asdf install pdm 2.15.0
       - asdf global pdm 2.15.0
-    pre_install:
+    post_install:
       - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH make dev-doc
     pre_build:
-      - CI_PAGES_URL=https://${READTHEDOCS_PROJECT}.readthedocs.io/${READTHEDOCS_LANGUAGE}/stable make changelog
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH CI_PAGES_URL=https://${READTHEDOCS_PROJECT}.readthedocs.io/${READTHEDOCS_LANGUAGE}/stable make changelog
+    post_build:
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH make doc-mypy doc-coverage
   os: ubuntu-22.04
   tools:
-    python: '3'
+    python: "3"
 sphinx:
   fail_on_warning: true
 version: 2

--- a/template/.readthedocs.yaml
+++ b/template/.readthedocs.yaml
@@ -21,8 +21,11 @@ build:
         then
           exit 183;
         fi
+    pre_create_environment:
+      - asdf plugin add pdm
+      - asdf install pdm 2.15.0
+      - asdf global pdm 2.15.0
     post_install:
-      - python -m pip install --upgrade --no-cache-dir pdm==2.15.0
       - make dev-doc
     pre_build:
       - CI_PAGES_URL=https://${READTHEDOCS_PROJECT}.readthedocs.io/${READTHEDOCS_LANGUAGE}/stable make changelog

--- a/template/.readthedocs.yaml
+++ b/template/.readthedocs.yaml
@@ -25,7 +25,7 @@ build:
       - asdf plugin add pdm
       - asdf install pdm 2.15.0
       - asdf global pdm 2.15.0
-    post_install:
+    pre_install:
       - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH make dev-doc
     pre_build:
       - CI_PAGES_URL=https://${READTHEDOCS_PROJECT}.readthedocs.io/${READTHEDOCS_LANGUAGE}/stable make changelog

--- a/template/.readthedocs.yaml.jinja
+++ b/template/.readthedocs.yaml.jinja
@@ -31,7 +31,7 @@ build:
       - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH make doc-mypy doc-coverage
   os: ubuntu-22.04
   tools:
-    python: "3"
+    python: "{{ default_py }}"
 sphinx:
   fail_on_warning: true
 version: 2

--- a/template/.renovaterc.json.jinja
+++ b/template/.renovaterc.json.jinja
@@ -24,8 +24,10 @@
 [%- endif %]
             ],
             "matchStrings": [
-                "pipx install (?<depName>.*?)==(?<currentValue>.*?)[;\n]",
-                "pip install.* (?<depName>.*?)==(?<currentValue>.*?)[\"\n]"
+                "asdf global (?<depName>.*?) (?<currentValue>.*?)\n",
+                "asdf install (?<depName>.*?) (?<currentValue>.*?)\n",
+                "pip install.* (?<depName>.*?)==(?<currentValue>.*?)[\"\n]",
+                "pipx install (?<depName>.*?)==(?<currentValue>.*?)[;\n]"
             ]
         },
         {

--- a/template/.renovaterc.json.jinja
+++ b/template/.renovaterc.json.jinja
@@ -132,7 +132,7 @@
             }
         },
         {
-            "matchManagers": [
+            "matchDatasources": [
                 "pypi"
             ],
             "postUpgradeTasks": {

--- a/template/.renovaterc.json.jinja
+++ b/template/.renovaterc.json.jinja
@@ -132,6 +132,17 @@
             }
         },
         {
+            "matchManagers": [
+                "pypi"
+            ],
+            "postUpgradeTasks": {
+                "commands": [
+                    "find template -type f -exec sed -i {{ '\'s|{{{depName}}} {{{currentValue}}}|{{{depName}}} {{{newValue}}}|g\' {} +' }}",
+                    "find template -type f -exec sed -i {{ '\'s|{{{depName}}}=={{{currentValue}}}|{{{depName}}}=={{{newValue}}}|g\' {} +' }}"
+                ]
+            }
+        },
+        {
             "matchDepTypes": [
                 "container",
                 "image",

--- a/template/.renovaterc.json.jinja
+++ b/template/.renovaterc.json.jinja
@@ -132,17 +132,6 @@
             }
         },
         {
-            "matchDatasources": [
-                "pypi"
-            ],
-            "postUpgradeTasks": {
-                "commands": [
-                    "find template -type f -exec sed -i {{ '\'s|{{{depName}}} {{{currentValue}}}|{{{depName}}} {{{newValue}}}|g\' {} +' }}",
-                    "find template -type f -exec sed -i {{ '\'s|{{{depName}}}=={{{currentValue}}}|{{{depName}}}=={{{newValue}}}|g\' {} +' }}"
-                ]
-            }
-        },
-        {
             "matchDepTypes": [
                 "container",
                 "image",
@@ -152,6 +141,17 @@
             "postUpgradeTasks": {
                 "commands": [
                     "find template -type f -exec sed -i {{ '\'s|{{{depName}}}:{{{currentValue}}}@{{{currentDigest}}}|{{{depName}}}:{{{newValue}}}@{{{newDigest}}}|g\' {} +' }}"
+                ]
+            }
+        },
+        {
+            "matchDatasources": [
+                "pypi"
+            ],
+            "postUpgradeTasks": {
+                "commands": [
+                    "find template -type f -exec sed -i {{ '\'s|{{{depName}}} {{{currentValue}}}|{{{depName}}} {{{newValue}}}|g\' {} +' }}",
+                    "find template -type f -exec sed -i {{ '\'s|{{{depName}}}=={{{currentValue}}}|{{{depName}}}=={{{newValue}}}|g\' {} +' }}"
                 ]
             }
         },

--- a/template/Makefile.jinja
+++ b/template/Makefile.jinja
@@ -6,9 +6,6 @@
 # Variables
 ########################################################################################
 
-# Global option for pdm, when in CI or readthedocs environment, no need to use venv.
-PDM_GLOBAL := $(shell [ "$$CI" = "true" ] || [ "$$READTHEDOCS" = "True" ] && echo "--global --project .")
-
 # Documentation target directory, will be adapted to specific folder for readthedocs.
 PUBLIC_DIR := $(shell [ "$$READTHEDOCS" = "True" ] && echo "$$READTHEDOCS_OUTPUT/html" || echo "public")
 
@@ -49,16 +46,16 @@ deepclean: clean
 
 # Install the package in editable mode.
 install:
-	pdm install $(PDM_GLOBAL) --prod
+	pdm install --prod
 
 # Install the package in editable mode with specific optional dependencies.
 dev-%:
-	pdm install $(PDM_GLOBAL) --dev --group $*
+	pdm install --dev --group $*
 
 # Prepare the development environment.
 # Install the pacakge in editable mode with all optional dependencies and pre-commit hoook.
 dev:
-	pdm install $(PDM_GLOBAL)
+	pdm install
 	if [ "$(CI)" != "true" ] && command -v pre-commit > /dev/null 2>&1; then pre-commit install; fi
 
 ########################################################################################
@@ -67,19 +64,19 @@ dev:
 
 # Check lint with mypy.
 mypy:
-	pdm run $(PDM_GLOBAL) python -m mypy .
+	pdm run python -m mypy .
 
 # Lint with ruff.
 ruff:
-	pdm run $(PDM_GLOBAL) python -m ruff check .
+	pdm run python -m ruff check .
 
 # Format with ruff.
 ruff-format:
-	pdm run $(PDM_GLOBAL) python -m ruff format --check .
+	pdm run python -m ruff format --check .
 
 # Check lint with toml-sort.
 toml-sort:
-	pdm run $(PDM_GLOBAL) toml-sort --check pyproject.toml
+	pdm run toml-sort --check pyproject.toml
 
 # Check lint with all linters.
 lint: mypy ruff ruff-format toml-sort
@@ -94,13 +91,13 @@ pre-commit:
 
 # Clean and run test with coverage.
 test-run:
-	pdm run $(PDM_GLOBAL) python -m coverage erase
-	pdm run $(PDM_GLOBAL) python -m coverage run -m pytest
+	pdm run python -m coverage erase
+	pdm run python -m coverage run -m pytest
 
 # Generate coverage report for terminal and xml.
 test: test-run
-	pdm run $(PDM_GLOBAL) python -m coverage report
-	pdm run $(PDM_GLOBAL) python -m coverage xml
+	pdm run python -m coverage report
+	pdm run python -m coverage xml
 
 ########################################################################################
 # Package
@@ -120,7 +117,7 @@ publish:
 
 # Generate documentation with auto build when changes happen.
 doc-autobuild:
-	pdm run $(PDM_GLOBAL) python -m sphinx_autobuild docs $(PUBLIC_DIR) \
+	pdm run python -m sphinx_autobuild docs $(PUBLIC_DIR) \
 		--watch README.md \
 		--watch src
 
@@ -131,24 +128,24 @@ changelog:
 		echo "Existing Changelog found at '$(CHANGELOG_URL)', download for incremental generation."; \
 		wget -q -O $(CHANGELOG_PATH) $(CHANGELOG_URL); \
 	fi
-	pdm run $(PDM_GLOBAL) git-changelog -ETrio $(CHANGELOG_PATH) -c conventional -s build,chore,ci,doc,feat,fix,perf,refactor,revert,style,test
+	pdm run git-changelog -ETrio $(CHANGELOG_PATH) -c conventional -s build,chore,ci,doc,feat,fix,perf,refactor,revert,style,test
 
 # Generate release notes from changelog.
 release-notes:
-	@pdm run $(PDM_GLOBAL) git-changelog --input $(CHANGELOG_PATH) --release-notes
+	@pdm run git-changelog --input $(CHANGELOG_PATH) --release-notes
 
 # Build documentation only from src.
 doc-gen:
-	pdm run $(PDM_GLOBAL) python -m sphinx.cmd.build docs $(PUBLIC_DIR)
+	pdm run python -m sphinx.cmd.build docs $(PUBLIC_DIR)
 
 # Generate mypy reports.
 doc-mypy: doc-gen
-	pdm run $(PDM_GLOBAL) python -m mypy src tests --html-report $(PUBLIC_DIR)/reports/mypy
+	pdm run python -m mypy src tests --html-report $(PUBLIC_DIR)/reports/mypy
 
 # Generate html coverage reports with badge.
 doc-coverage: test-run doc-gen
-	pdm run $(PDM_GLOBAL) python -m coverage html -d $(PUBLIC_DIR)/reports/coverage
-	pdm run $(PDM_GLOBAL) bash scripts/generate-coverage-badge.sh $(PUBLIC_DIR)/_static/badges
+	pdm run python -m coverage html -d $(PUBLIC_DIR)/reports/coverage
+	pdm run bash scripts/generate-coverage-badge.sh $(PUBLIC_DIR)/_static/badges
 
 # Generate all documentation with reports.
 doc: changelog doc-gen doc-mypy doc-coverage

--- a/template/Makefile.jinja
+++ b/template/Makefile.jinja
@@ -7,7 +7,7 @@
 ########################################################################################
 
 # Documentation target directory, will be adapted to specific folder for readthedocs.
-PUBLIC_DIR := $(shell [ "$$READTHEDOCS" = "True" ] && echo "$$READTHEDOCS_OUTPUT/html" || echo "public")
+PUBLIC_DIR := $(shell [ "$$READTHEDOCS" = "True" ] && echo "$${READTHEDOCS_OUTPUT}html" || echo "public")
 
 # URL and Path of changelog source code.
 CHANGELOG_URL := $(shell echo $${CI_PAGES_URL:-https://{{ page_url() }}}/_sources/changelog.md.txt)
@@ -139,11 +139,11 @@ doc-gen:
 	pdm run python -m sphinx.cmd.build docs $(PUBLIC_DIR)
 
 # Generate mypy reports.
-doc-mypy: doc-gen
+doc-mypy:
 	pdm run python -m mypy src tests --html-report $(PUBLIC_DIR)/reports/mypy
 
 # Generate html coverage reports with badge.
-doc-coverage: test-run doc-gen
+doc-coverage: test-run
 	pdm run python -m coverage html -d $(PUBLIC_DIR)/reports/coverage
 	pdm run bash scripts/generate-coverage-badge.sh $(PUBLIC_DIR)/_static/badges
 

--- a/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/release.yml.jinja
+++ b/template/[% if repo_host_type == 'github.com' %].github[% endif %]/workflows/release.yml.jinja
@@ -17,8 +17,6 @@ jobs:
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - run: env | sort
       - run: make dev-doc
-        env:
-          PDM_NO_EDITABLE: true
       - run: make doc
         env:
           CI_PAGES_URL: {{ '${{ steps.pages.outputs.base_url }}' }}

--- a/template/[% if repo_host_type == 'gitlab.com' or repo_host_type == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/release.yml.jinja
+++ b/template/[% if repo_host_type == 'gitlab.com' or repo_host_type == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/release.yml.jinja
@@ -8,7 +8,7 @@ pages-build:
   rules:
     - if: $CI_COMMIT_TAG =~ /^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-?(a|b|rc)(0|[1-9][0-9]*)?)?$/
   script:
-    - PDM_NO_EDITABLE=true make dev-doc
+    - make dev-doc
     - make doc
     - make release-notes > release-notes.md
   stage: release

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -4,7 +4,7 @@
 [build-system]
 build-backend = "pdm.backend"
 requires = [
-  "pdm-backend",
+  "pdm-backend==2.2.1",
 ]
 
 [project]


### PR DESCRIPTION
1. Avoid unnecessary no editable installtion since upstream change: https://github.com/pdm-project/pdm-backend/commit/e6fcd5fcc2abae9ab25a9d69c71fd066de184110
2. Refine `.readthdocs.yaml` mostly refer to https://github.com/pdm-project/pdm/blob/main/.readthedocs.yaml
   1. Set `VIRTUAL_ENV` as a trick, ref: https://github.com/pdm-project/pdm/issues/2856#issuecomment-2081301478
   2. Install pdm with asdf
3. Update pdm installed with asdf with renovate
4. pin `pdm-backend` and update with renovate including template