### PR TITLE
ci: integrate semantic release in GitLab CI/CD

### DIFF
--- a/.gitlab/workflows/ci.yml
+++ b/.gitlab/workflows/ci.yml
@@ -33,6 +33,7 @@ consistency:
   interruptible: true
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push"
+      allow_failure: true
     - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
   script:
     - git config --global user.name gitlab-ci

--- a/.gitlab/workflows/ci.yml
+++ b/.gitlab/workflows/ci.yml
@@ -33,7 +33,6 @@ consistency:
   interruptible: true
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push"
-      allow_failure: true
     - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
   script:
     - git config --global user.name gitlab-ci
@@ -49,7 +48,7 @@ semantic-release:
     name: node:20.13.1
   interruptible: true
   rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push" && $CI_PROJECT_NAMESPACE == "huxuan8528" && $CI_PROJECT_NAME == "ss-python"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push" && $CI_PROJECT_NAMESPACE == "serious-scaffold" && $CI_PROJECT_NAME == "ss-python"
   script:
     - >
       npx

--- a/.gitlab/workflows/ci.yml
+++ b/.gitlab/workflows/ci.yml
@@ -43,3 +43,17 @@ consistency:
     - git status --porcelain
     - test -z "$(git status --porcelain)"
   stage: ci
+semantic-release:
+  image:
+    name: node:20.13.1
+  interruptible: true
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push" && $CI_PROJECT_NAMESPACE == "huxuan8528" && $CI_PROJECT_NAME == "ss-python"
+  script:
+    - >
+      npx
+      -p @semantic-release/gitlab@13
+      -p conventional-changelog-conventionalcommits@7
+      -p semantic-release@23
+      semantic-release
+  stage: release

--- a/.gitlab/workflows/release.yml
+++ b/.gitlab/workflows/release.yml
@@ -2,8 +2,6 @@ pages-build:
   artifacts:
     paths:
       - public
-      - docs/changelog.md
-      - release-notes.md
   cache:
     paths:
       - .venv
@@ -17,26 +15,22 @@ pages-build:
   script:
     - make dev-doc
     - make doc
-    - make release-notes > release-notes.md
   stage: release
-release-publish:
-  image: registry.gitlab.com/gitlab-org/release-cli:v0.18.0@sha256:696013aea0f2a20482800ce3a77341f840d7c7ec17bd78bd555e0bd6c00e4f11
+pages:
+  artifacts:
+    paths:
+      - public
   needs:
     - pages-build
-  release:
-    description: release-notes.md
-    tag_name: $CI_COMMIT_TAG
   rules:
     - if: $CI_COMMIT_TAG =~ /^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-?(a|b|rc)(0|[1-9][0-9]*)?)?$/
   script:
-    - echo "Running the release job."
+    - echo "Running the pages job."
   stage: release
   variables:
     GIT_STRATEGY: none
 container-publish:
   image: docker:26.1.2@sha256:c890c327e515cdccd14e593fb5450e4375e791ab0520795948134cb87b45aaa7
-  needs:
-    - release-publish
   parallel:
     matrix:
       - PYTHON_VERSION:
@@ -82,24 +76,8 @@ container-publish:
     PYTHON_VERSION: ${PYTHON_VERSION}
     SOURCE_DATE_EPOCH: 0
 package-publish:
-  needs:
-    - release-publish
   rules:
     - if: $CI_COMMIT_TAG =~ /^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-?(a|b|rc)(0|[1-9][0-9]*)?)?$/
   script:
     - make publish
   stage: release
-pages:
-  artifacts:
-    paths:
-      - public
-  needs:
-    - pages-build
-    - release-publish
-  rules:
-    - if: $CI_COMMIT_TAG =~ /^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-?(a|b|rc)(0|[1-9][0-9]*)?)?$/
-  script:
-    - echo "Running the pages job."
-  stage: release
-  variables:
-    GIT_STRATEGY: none

--- a/package.json
+++ b/package.json
@@ -118,12 +118,7 @@
                     }
                 }
             ],
-            [
-                "@semantic-release/gitlab",
-                {
-                    "gitlabUrl": "https://gitlab.com"
-                }
-            ]
+            "@semantic-release/github"
         ],
         "preset": "conventionalcommits"
     }

--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
         ]
     },
     "release": {
-        "branches": [
-            "xuan.hu/gitlab-semantic-release"
-        ],
         "plugins": [
             [
                 "@semantic-release/commit-analyzer",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
         ]
     },
     "release": {
+        "branches": [
+            "xuan.hu/gitlab-semantic-release"
+        ],
         "plugins": [
             [
                 "@semantic-release/commit-analyzer",
@@ -118,7 +121,12 @@
                     }
                 }
             ],
-            "@semantic-release/github"
+            [
+                "@semantic-release/gitlab",
+                {
+                    "gitlabUrl": "https://gitlab.com"
+                }
+            ]
         ],
         "preset": "conventionalcommits"
     }

--- a/template/[% if repo_platform == 'gitlab' or repo_platform == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/ci.yml.jinja
+++ b/template/[% if repo_platform == 'gitlab' or repo_platform == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/ci.yml.jinja
@@ -56,3 +56,17 @@ consistency:
     - test -z "$(git status --porcelain)"
   stage: ci
 [%- endif %]
+semantic-release:
+  image:
+    name: node:20.13.1
+  interruptible: true
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push" && $CI_PROJECT_NAMESPACE == "serious-scaffold" && $CI_PROJECT_NAME == "ss-python"
+  script:
+    - >
+      npx
+      -p @semantic-release/gitlab@13
+      -p conventional-changelog-conventionalcommits@7
+      -p semantic-release@23
+      semantic-release
+  stage: release

--- a/template/[% if repo_platform == 'gitlab' or repo_platform == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/ci.yml.jinja
+++ b/template/[% if repo_platform == 'gitlab' or repo_platform == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/ci.yml.jinja
@@ -61,7 +61,7 @@ semantic-release:
     name: node:20.13.1
   interruptible: true
   rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push" && $CI_PROJECT_NAMESPACE == "serious-scaffold" && $CI_PROJECT_NAME == "ss-python"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push" && $CI_PROJECT_NAMESPACE == "{{ repo_namespace }}" && $CI_PROJECT_NAME == "{{ repo_name }}"
   script:
     - >
       npx

--- a/template/[% if repo_platform == 'gitlab' or repo_platform == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/release.yml.jinja
+++ b/template/[% if repo_platform == 'gitlab' or repo_platform == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/release.yml.jinja
@@ -3,8 +3,6 @@ pages-build:
   artifacts:
     paths:
       - public
-      - docs/changelog.md
-      - release-notes.md
   cache:
     paths:
       - .venv
@@ -18,26 +16,22 @@ pages-build:
   script:
     - make dev-doc
     - make doc
-    - make release-notes > release-notes.md
   stage: release
-release-publish:
-  image: registry.gitlab.com/gitlab-org/release-cli:v0.18.0@sha256:696013aea0f2a20482800ce3a77341f840d7c7ec17bd78bd555e0bd6c00e4f11
+pages:
+  artifacts:
+    paths:
+      - public
   needs:
     - pages-build
-  release:
-    description: release-notes.md
-    tag_name: $CI_COMMIT_TAG
   rules:
     - if: $CI_COMMIT_TAG =~ /^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-?(a|b|rc)(0|[1-9][0-9]*)?)?$/
   script:
-    - echo "Running the release job."
+    - echo "Running the pages job."
   stage: release
   variables:
     GIT_STRATEGY: none
 container-publish:
   image: docker:26.1.2@sha256:c890c327e515cdccd14e593fb5450e4375e791ab0520795948134cb87b45aaa7
-  needs:
-    - release-publish
   parallel:
     matrix:
       - PYTHON_VERSION:
@@ -93,24 +87,8 @@ container-publish:
     PYTHON_VERSION: ${PYTHON_VERSION}
     SOURCE_DATE_EPOCH: 0
 package-publish:
-  needs:
-    - release-publish
   rules:
     - if: $CI_COMMIT_TAG =~ /^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-?(a|b|rc)(0|[1-9][0-9]*)?)?$/
   script:
     - make publish
   stage: release
-pages:
-  artifacts:
-    paths:
-      - public
-  needs:
-    - pages-build
-    - release-publish
-  rules:
-    - if: $CI_COMMIT_TAG =~ /^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-?(a|b|rc)(0|[1-9][0-9]*)?)?$/
-  script:
-    - echo "Running the pages job."
-  stage: release
-  variables:
-    GIT_STRATEGY: none

--- a/template/package.json.jinja
+++ b/template/package.json.jinja
@@ -118,7 +118,18 @@
                     }
                 }
             ],
+[%- if repo_platform == 'github' %]
             "@semantic-release/github"
+[%- elif repo_platform == 'gitlab' %]
+            "@semantic-release/gitlab"
+[%- elif repo_platform == 'gitlab-self-managed' %]
+            [
+                "@semantic-release/gitlab",
+                {
+                    "gitlabUrl": "https://{{ repo_host }}"
+                }
+            ]
+[%- endif %]
         ],
         "preset": "conventionalcommits"
     }


### PR DESCRIPTION
1. pipeline for semantic-release: https://gitlab.com/huxuan8528/ss-python/-/pipelines/1294606691
2. pipeline for release after semantic-release: https://gitlab.com/huxuan8528/ss-python/-/pipelines/1294637957
3. New release: https://gitlab.com/huxuan8528/ss-python/-/releases/v0.0.51

BTW, documentation are not included in this pull request and it was noted as subtasks in #549 