### PR TITLE
ci: use container image for commitlint on GitHub Actions

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -4,12 +4,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   commitlint:
+    container:
+      image: commitlint/commitlint:19.3.0@sha256:54438df1d11ac1a7ad0e7b794e24f3e78d5490ec5303c2066fd93e53cf70d0fe
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - run: env | sort
-      - name: Install commitlint with conventional config
-        run: npm install --save-dev @commitlint/config-conventional @commitlint/cli
+      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - name: Validate the latest commit message with commitlint
         if: github.event_name == 'push'
         run: echo "${{ github.event.head_commit.message }}" | npx commitlint

--- a/template/[% if repo_platform == 'github' %].github[% endif %]/workflows/commitlint.yml
+++ b/template/[% if repo_platform == 'github' %].github[% endif %]/workflows/commitlint.yml
@@ -4,12 +4,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   commitlint:
+    container:
+      image: commitlint/commitlint:19.3.0@sha256:54438df1d11ac1a7ad0e7b794e24f3e78d5490ec5303c2066fd93e53cf70d0fe
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - run: env | sort
-      - name: Install commitlint with conventional config
-        run: npm install --save-dev @commitlint/config-conventional @commitlint/cli
+      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - name: Validate the latest commit message with commitlint
         if: github.event_name == 'push'
         run: echo "${{ github.event.head_commit.message }}" | npx commitlint


### PR DESCRIPTION
I suppose to use `npx` to run `commitlint` directly but it turns out there is still an open issue from 2019 (https://github.com/conventional-changelog/commitlint/issues/613), so finally I give up and decide to use container image instead.