### PR TITLE
ci: fix variable null chek on GitLab CI/CD

### DIFF
--- a/.gitlab/workflows/ci.yml
+++ b/.gitlab/workflows/ci.yml
@@ -48,7 +48,7 @@ semantic-release:
     name: node:20.13.1
   interruptible: true
   rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push" && $CI_PROJECT_NAMESPACE == "huxuan8528" && $CI_PROJECT_NAME == "ss-python" && $GITLAB_TOKEN != ""
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push" && $CI_PROJECT_NAMESPACE == "huxuan8528" && $CI_PROJECT_NAME == "ss-python" && $GITLAB_TOKEN != null
   script:
     - >
       npx

--- a/.gitlab/workflows/ci.yml
+++ b/.gitlab/workflows/ci.yml
@@ -49,7 +49,7 @@ semantic-release:
     name: node:20.13.1
   interruptible: true
   rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push" && $CI_PROJECT_NAMESPACE == "huxuan8528" && $CI_PROJECT_NAME == "ss-python" && $PAT != null
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push" && $CI_PROJECT_NAMESPACE == "huxuan8528" && $CI_PROJECT_NAME == "ss-python" && $GITLAB_TOKEN != null
   script:
     - >
       npx

--- a/.gitlab/workflows/ci.yml
+++ b/.gitlab/workflows/ci.yml
@@ -48,7 +48,7 @@ semantic-release:
     name: node:20.13.1
   interruptible: true
   rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push" && $CI_PROJECT_NAMESPACE == "huxuan8528" && $CI_PROJECT_NAME == "ss-python" && $PAT != ""
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push" && $CI_PROJECT_NAMESPACE == "huxuan8528" && $CI_PROJECT_NAME == "ss-python" && $GITLAB_TOKEN != ""
   script:
     - >
       npx

--- a/.gitlab/workflows/ci.yml
+++ b/.gitlab/workflows/ci.yml
@@ -49,7 +49,7 @@ semantic-release:
     name: node:20.13.1
   interruptible: true
   rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push" && $CI_PROJECT_NAMESPACE == "huxuan8528" && $CI_PROJECT_NAME == "ss-python" && $GITLAB_TOKEN != null
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push" && $CI_PROJECT_NAMESPACE == "huxuan8528" && $CI_PROJECT_NAME == "ss-python" && $PAT != null
   script:
     - >
       npx

--- a/.gitlab/workflows/ci.yml
+++ b/.gitlab/workflows/ci.yml
@@ -48,7 +48,7 @@ semantic-release:
     name: node:20.13.1
   interruptible: true
   rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push" && $CI_PROJECT_NAMESPACE == "huxuan8528" && $CI_PROJECT_NAME == "ss-python" && $PAT != null
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push" && $CI_PROJECT_NAMESPACE == "huxuan8528" && $CI_PROJECT_NAME == "ss-python" && $PAT != ""
   script:
     - >
       npx

--- a/.gitlab/workflows/ci.yml
+++ b/.gitlab/workflows/ci.yml
@@ -48,7 +48,7 @@ semantic-release:
     name: node:20.13.1
   interruptible: true
   rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push" && $CI_PROJECT_NAMESPACE == "huxuan8528" && $CI_PROJECT_NAME == "ss-python" && $GITLAB_TOKEN != null
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push" && $CI_PROJECT_NAMESPACE == "huxuan8528" && $CI_PROJECT_NAME == "ss-python" && $PAT != null
   script:
     - >
       npx

--- a/.gitlab/workflows/ci.yml
+++ b/.gitlab/workflows/ci.yml
@@ -48,7 +48,7 @@ semantic-release:
     name: node:20.13.1
   interruptible: true
   rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push" && $CI_PROJECT_NAMESPACE == "huxuan8528" && $CI_PROJECT_NAME == "ss-python" && $PAT != null
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push" && $CI_PROJECT_NAMESPACE == "serious-scaffold" && $CI_PROJECT_NAME == "ss-python" && $PAT != null
   script:
     - >
       npx

--- a/.gitlab/workflows/ci.yml
+++ b/.gitlab/workflows/ci.yml
@@ -33,6 +33,7 @@ consistency:
   interruptible: true
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push"
+      allow_failure: true
     - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
   script:
     - git config --global user.name gitlab-ci
@@ -48,7 +49,7 @@ semantic-release:
     name: node:20.13.1
   interruptible: true
   rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push" && $CI_PROJECT_NAMESPACE == "serious-scaffold" && $CI_PROJECT_NAME == "ss-python" && $GITLAB_TOKEN != null
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push" && $CI_PROJECT_NAMESPACE == "huxuan8528" && $CI_PROJECT_NAME == "ss-python" && $GITLAB_TOKEN != ""
   script:
     - >
       npx

--- a/.gitlab/workflows/ci.yml
+++ b/.gitlab/workflows/ci.yml
@@ -49,7 +49,7 @@ semantic-release:
     name: node:20.13.1
   interruptible: true
   rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push" && $CI_PROJECT_NAMESPACE == "huxuan8528" && $CI_PROJECT_NAME == "ss-python" && $GITLAB_TOKEN != ""
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push" && $CI_PROJECT_NAMESPACE == "huxuan8528" && $CI_PROJECT_NAME == "ss-python" && $PAT != null
   script:
     - >
       npx

--- a/.gitlab/workflows/ci.yml
+++ b/.gitlab/workflows/ci.yml
@@ -33,7 +33,6 @@ consistency:
   interruptible: true
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push"
-      allow_failure: true
     - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
   script:
     - git config --global user.name gitlab-ci

--- a/.gitlab/workflows/renovate.yml
+++ b/.gitlab/workflows/renovate.yml
@@ -5,7 +5,7 @@ renovate:
       - renovate/cache/renovate/repository/
   image: renovate/renovate:37.356.1-full@sha256:e54b1093f2a751b4ac94988279d2621f068e79c77227d9654165a06ae3d50ad3
   rules:
-    - if: $CI_PIPELINE_SOURCE == "schedule" && $RENOVATE_TOKEN != null
+    - if: $CI_PIPELINE_SOURCE == "schedule" && $RENOVATE_TOKEN != ""
   script: renovate $RENOVATE_EXTRA_FLAG
   stage: build
   variables:

--- a/.gitlab/workflows/renovate.yml
+++ b/.gitlab/workflows/renovate.yml
@@ -5,7 +5,7 @@ renovate:
       - renovate/cache/renovate/repository/
   image: renovate/renovate:37.356.1-full@sha256:e54b1093f2a751b4ac94988279d2621f068e79c77227d9654165a06ae3d50ad3
   rules:
-    - if: $CI_PIPELINE_SOURCE == "schedule" && $RENOVATE_TOKEN != ""
+    - if: $CI_PIPELINE_SOURCE == "schedule" && $PAT != null
   script: renovate $RENOVATE_EXTRA_FLAG
   stage: build
   variables:

--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
         ]
     },
     "release": {
-        "branches": [
-            "xuan.hu/gitlab-ci-fix"
-        ],
         "plugins": [
             [
                 "@semantic-release/commit-analyzer",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
         ]
     },
     "release": {
+        "branches": [
+            "xuan.hu/gitlab-ci-fix"
+        ],
         "plugins": [
             [
                 "@semantic-release/commit-analyzer",

--- a/template/[% if repo_platform == 'gitlab' or repo_platform == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/ci.yml.jinja
+++ b/template/[% if repo_platform == 'gitlab' or repo_platform == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/ci.yml.jinja
@@ -61,7 +61,7 @@ semantic-release:
     name: node:20.13.1
   interruptible: true
   rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push" && $CI_PROJECT_NAMESPACE == "{{ repo_namespace }}" && $CI_PROJECT_NAME == "{{ repo_name }}" && $GITLAB_TOKEN != null
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push" && $CI_PROJECT_NAMESPACE == "{{ repo_namespace }}" && $CI_PROJECT_NAME == "{{ repo_name }}" && $PAT != null
   script:
     - >
       npx

--- a/template/[% if repo_platform == 'gitlab' or repo_platform == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/renovate.yml
+++ b/template/[% if repo_platform == 'gitlab' or repo_platform == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/renovate.yml
@@ -5,7 +5,7 @@ renovate:
       - renovate/cache/renovate/repository/
   image: renovate/renovate:37.356.1-full@sha256:e54b1093f2a751b4ac94988279d2621f068e79c77227d9654165a06ae3d50ad3
   rules:
-    - if: $CI_PIPELINE_SOURCE == "schedule" && $RENOVATE_TOKEN != null
+    - if: $CI_PIPELINE_SOURCE == "schedule" && $PAT != null
   script: renovate $RENOVATE_EXTRA_FLAG
   stage: build
   variables:


### PR DESCRIPTION
The varialbe check on GitLab CI/CD is quite strange:

When assign `$PAT` to `$GITLAB_TOKEN` and `$PAT` is NEVER configured:

1. `$GITLAB_TOKEN != null`: the [job](https://gitlab.com/huxuan8528/ss-python/-/pipelines/1296849230) will be triggered. 
2. `$GITALB_TOKEN != ""`: the [job](https://gitlab.com/huxuan8528/ss-python/-/pipelines/1296848929) will be triggered.
3. `$PAT != null`, the [job](https://gitlab.com/huxuan8528/ss-python/-/pipelines/1296849378) will NOT be triggered. 
4. `$PAT != ""`, the [job](https://gitlab.com/huxuan8528/ss-python/-/pipelines/1296848448) will be triggered.

In conclusion, we have to `$PAT != null` to avoid unexpected job run.

Some related reference:
- https://gitlab.com/gitlab-org/gitlab/-/issues/206960
- https://gitlab.com/gitlab-org/gitlab/-/issues/220562