### PR TITLE
chore: use slim renovate with constraints

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -12,7 +12,7 @@ jobs:
         RENOVATE_PLATFORM: github
         RENOVATE_REPOSITORIES: '["${{ github.repository }}"]'
         RENOVATE_REPOSITORY_CACHE: enabled
-      image: ghcr.io/renovatebot/renovate:37.368.8
+      image: ghcr.io/renovatebot/renovate:37.374.3@sha256:a12297dde4fad3d54111c3e4471aae726e7bc99bd407b74886394c41bc227250
       options: '--user root'
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -8,12 +8,12 @@ jobs:
         RENOVATE_BRANCH_PREFIX: renovate-github/
         RENOVATE_ENABLED: ${{ vars.RENOVATE_ENABLED || true }}
         RENOVATE_ENABLED_MANAGERS: '["pep621", "github-actions", "gitlabci", "regex", "pre-commit"]'
-        RENOVATE_OPTIMIZE_FOR_DISABLED: "true"
+        RENOVATE_OPTIMIZE_FOR_DISABLED: 'true'
         RENOVATE_PLATFORM: github
         RENOVATE_REPOSITORIES: '["${{ github.repository }}"]'
         RENOVATE_REPOSITORY_CACHE: enabled
-      image: ghcr.io/renovatebot/renovate:37.368.8-full@sha256:ec42750b18504058611851753fb5822522c1999a39476eefc083be70f179a74e
-      options: "--user root"
+      image: ghcr.io/renovatebot/renovate:37.368.8
+      options: '--user root'
     runs-on: ubuntu-22.04
     steps:
       - run: env | sort
@@ -48,5 +48,5 @@ jobs:
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron: "*/15 0-3 * * 1"
+    - cron: '*/15 0-3 * * 1'
   workflow_dispatch: null

--- a/.gitlab/workflows/renovate.yml
+++ b/.gitlab/workflows/renovate.yml
@@ -3,7 +3,7 @@ renovate:
     key: ${CI_COMMIT_REF_SLUG}-renovate
     paths:
       - renovate/cache/renovate/repository/
-  image: renovate/renovate:37.368.8
+  image: renovate/renovate:37.374.3@sha256:a12297dde4fad3d54111c3e4471aae726e7bc99bd407b74886394c41bc227250
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule" && $PAT != null
   script: renovate $RENOVATE_EXTRA_FLAG

--- a/.gitlab/workflows/renovate.yml
+++ b/.gitlab/workflows/renovate.yml
@@ -3,7 +3,7 @@ renovate:
     key: ${CI_COMMIT_REF_SLUG}-renovate
     paths:
       - renovate/cache/renovate/repository/
-  image: renovate/renovate:37.368.8-full@sha256:ec42750b18504058611851753fb5822522c1999a39476eefc083be70f179a74e
+  image: renovate/renovate:37.368.8
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule" && $PAT != null
   script: renovate $RENOVATE_EXTRA_FLAG

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
         files: .pre-commit-config.yaml
       - id: trailing-whitespace
   - repo: https://github.com/renovatebot/pre-commit-hooks
-    rev: 37.368.8
+    rev: 37.374.3
     hooks:
       - id: renovate-config-validator
   - repo: local

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -63,7 +63,7 @@
             "customType": "regex",
             "datasourceTemplate": "pypi",
             "depNameTemplate": "pdm",
-            "description": "Match pdm version specified in renovate constraints",
+            "description": "Match pdm version specified in the renovate constraints",
             "fileMatch": [
                 "^\\.renovaterc\\.json$",
                 "^template/\\.renovaterc\\.json\\.jinja$"

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,5 +1,9 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "constraints": {
+        "pdm": "2.15.2",
+        "python": "3.12"
+    },
     "customManagers": [
         {
             "customType": "regex",
@@ -44,8 +48,8 @@
         },
         {
             "customType": "regex",
-            "datasourceTemplate": "github-tags",
-            "depNameTemplate": "pdm-project/pdm",
+            "datasourceTemplate": "pypi",
+            "depNameTemplate": "pdm",
             "description": "Match pdm version specified in setup-pdm GitHub Action",
             "fileMatch": [
                 "^\\.github/workflows/.+\\.yml$",
@@ -53,8 +57,20 @@
             ],
             "matchStrings": [
                 "uses: pdm-project/setup-pdm[\\s\\S]+?\\sversion: (?<currentValue>.*)\n"
+            ]
+        },
+        {
+            "customType": "regex",
+            "datasourceTemplate": "pypi",
+            "depNameTemplate": "pdm",
+            "description": "Match pdm version specified in renovate constraints",
+            "fileMatch": [
+                "^\\.renovaterc\\.json$",
+                "^template/\\.renovaterc\\.json\\.jinja$"
             ],
-            "versioningTemplate": "semver"
+            "matchStrings": [
+                "\"pdm\": \"(?<currentValue>.*)\""
+            ]
         },
         {
             "customType": "regex",
@@ -196,8 +212,7 @@
                 "pypi"
             ],
             "matchDepNames": [
-                "pdm",
-                "pdm-project/pdm"
+                "pdm"
             ]
         },
         {

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -2,7 +2,7 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "constraints": {
         "pdm": "2.15.2",
-        "python": "3.12"
+        "python": "==3.12"
     },
     "customManagers": [
         {

--- a/docs/management/update.md
+++ b/docs/management/update.md
@@ -29,6 +29,7 @@ The project template tracks the following dependencies:
    1. Python packages installed with pip, pipx and asdf, listed in the README, DevContainer Dockerfile, GitHub Actions, GitLab CI/CD, ReadTheDocs configuration, Renovate configuration and documentation.
    1. Debian packages installed in the DevContainer Dockerfile.
    1. PDM version specified in the `pdm-project/setup-pdm` GitHub action.
+   1. PDM version specified in the renovate constraints.
    1. NPM packages used with npx.
    1. The project template itself.
 

--- a/template/.pre-commit-config.yaml.jinja
+++ b/template/.pre-commit-config.yaml.jinja
@@ -29,7 +29,7 @@ repos:
         files: .pre-commit-config.yaml
       - id: trailing-whitespace
   - repo: https://github.com/renovatebot/pre-commit-hooks
-    rev: 37.368.8
+    rev: 37.374.3
     hooks:
       - id: renovate-config-validator
   - repo: local

--- a/template/.renovaterc.json.jinja
+++ b/template/.renovaterc.json.jinja
@@ -70,7 +70,7 @@
             "customType": "regex",
             "datasourceTemplate": "pypi",
             "depNameTemplate": "pdm",
-            "description": "Match pdm version specified in renovate constraints",
+            "description": "Match pdm version specified in the renovate constraints",
             "fileMatch": [
                 "^\\.renovaterc\\.json$"
 [%- if project_name == "Serious Scaffold Python" %],

--- a/template/.renovaterc.json.jinja
+++ b/template/.renovaterc.json.jinja
@@ -3,7 +3,7 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "constraints": {
         "pdm": "2.15.2",
-        "python": "{{ default_py }}"
+        "python": "=={{ default_py }}"
     },
     "customManagers": [
         {

--- a/template/.renovaterc.json.jinja
+++ b/template/.renovaterc.json.jinja
@@ -1,6 +1,10 @@
 [% from pathjoin("includes", "version_compare.jinja") import version_higher_than -%]
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "constraints": {
+        "pdm": "2.15.2",
+        "python": "{{ default_py }}"
+    },
     "customManagers": [
         {
             "customType": "regex",
@@ -49,8 +53,8 @@
         },
         {
             "customType": "regex",
-            "datasourceTemplate": "github-tags",
-            "depNameTemplate": "pdm-project/pdm",
+            "datasourceTemplate": "pypi",
+            "depNameTemplate": "pdm",
             "description": "Match pdm version specified in setup-pdm GitHub Action",
             "fileMatch": [
                 "^\\.github/workflows/.+\\.yml$"
@@ -60,8 +64,22 @@
             ],
             "matchStrings": [
                 "uses: pdm-project/setup-pdm[\\s\\S]+?\\sversion: (?<currentValue>.*)\n"
+            ]
+        },
+        {
+            "customType": "regex",
+            "datasourceTemplate": "pypi",
+            "depNameTemplate": "pdm",
+            "description": "Match pdm version specified in renovate constraints",
+            "fileMatch": [
+                "^\\.renovaterc\\.json$"
+[%- if project_name == "Serious Scaffold Python" %],
+                "^template/\\.renovaterc\\.json\\.jinja$"
+[%- endif %]
             ],
-            "versioningTemplate": "semver"
+            "matchStrings": [
+                "\"pdm\": \"(?<currentValue>.*)\""
+            ]
         },
         {
             "customType": "regex",
@@ -209,8 +227,7 @@
                 "pypi"
             ],
             "matchDepNames": [
-                "pdm",
-                "pdm-project/pdm"
+                "pdm"
             ]
         },
         {

--- a/template/[% if repo_platform == 'github' %].github[% endif %]/workflows/renovate.yml.jinja
+++ b/template/[% if repo_platform == 'github' %].github[% endif %]/workflows/renovate.yml.jinja
@@ -16,7 +16,7 @@ jobs:
         RENOVATE_PLATFORM: github
         RENOVATE_REPOSITORIES: '["{{ '${{ github.repository }}' }}"]'
         RENOVATE_REPOSITORY_CACHE: enabled
-      image: ghcr.io/renovatebot/renovate:37.368.8
+      image: ghcr.io/renovatebot/renovate:37.374.3@sha256:a12297dde4fad3d54111c3e4471aae726e7bc99bd407b74886394c41bc227250
       options: '--user root'
     runs-on: ubuntu-22.04
     steps:

--- a/template/[% if repo_platform == 'github' %].github[% endif %]/workflows/renovate.yml.jinja
+++ b/template/[% if repo_platform == 'github' %].github[% endif %]/workflows/renovate.yml.jinja
@@ -12,12 +12,12 @@ jobs:
 [%- else %]
         RENOVATE_ENABLED_MANAGERS: '["pep621", "github-actions", "regex", "pre-commit"]'
 [%- endif %]
-        RENOVATE_OPTIMIZE_FOR_DISABLED: "true"
+        RENOVATE_OPTIMIZE_FOR_DISABLED: 'true'
         RENOVATE_PLATFORM: github
         RENOVATE_REPOSITORIES: '["{{ '${{ github.repository }}' }}"]'
         RENOVATE_REPOSITORY_CACHE: enabled
-      image: ghcr.io/renovatebot/renovate:37.368.8-full@sha256:ec42750b18504058611851753fb5822522c1999a39476eefc083be70f179a74e
-      options: "--user root"
+      image: ghcr.io/renovatebot/renovate:37.368.8
+      options: '--user root'
     runs-on: ubuntu-22.04
     steps:
       - run: env | sort
@@ -52,5 +52,5 @@ jobs:
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron: "*/15 0-3 * * 1"
+    - cron: '*/15 0-3 * * 1'
   workflow_dispatch: null

--- a/template/[% if repo_platform == 'gitlab' or repo_platform == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/renovate.yml
+++ b/template/[% if repo_platform == 'gitlab' or repo_platform == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/renovate.yml
@@ -3,7 +3,7 @@ renovate:
     key: ${CI_COMMIT_REF_SLUG}-renovate
     paths:
       - renovate/cache/renovate/repository/
-  image: renovate/renovate:37.368.8
+  image: renovate/renovate:37.374.3@sha256:a12297dde4fad3d54111c3e4471aae726e7bc99bd407b74886394c41bc227250
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule" && $PAT != null
   script: renovate $RENOVATE_EXTRA_FLAG

--- a/template/[% if repo_platform == 'gitlab' or repo_platform == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/renovate.yml
+++ b/template/[% if repo_platform == 'gitlab' or repo_platform == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/renovate.yml
@@ -3,7 +3,7 @@ renovate:
     key: ${CI_COMMIT_REF_SLUG}-renovate
     paths:
       - renovate/cache/renovate/repository/
-  image: renovate/renovate:37.368.8-full@sha256:ec42750b18504058611851753fb5822522c1999a39476eefc083be70f179a74e
+  image: renovate/renovate:37.368.8
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule" && $PAT != null
   script: renovate $RENOVATE_EXTRA_FLAG

--- a/template/docs/management/update.md
+++ b/template/docs/management/update.md
@@ -29,6 +29,7 @@ The project template tracks the following dependencies:
    1. Python packages installed with pip, pipx and asdf, listed in the README, DevContainer Dockerfile, GitHub Actions, GitLab CI/CD, ReadTheDocs configuration, Renovate configuration and documentation.
    1. Debian packages installed in the DevContainer Dockerfile.
    1. PDM version specified in the `pdm-project/setup-pdm` GitHub action.
+   1. PDM version specified in the renovate constraints.
    1. NPM packages used with npx.
    1. The project template itself.
 


### PR DESCRIPTION
1. Use slim version of renovate container image
2. Constraints python and pdm version in Renovate.
3. Manage the pdm version in the renovate constraints by renovate.
4. Unify pdm version specified in `pdm-project/setup-pdm` GitHub Actions.
5. Update related documentation.

- GitHub Actions: https://github.com/huxuan/ss-python/actions/runs/9203981154/job/25316623373
   - Search keyword "install-tool" and "constraints" to see how it takes effect
- Pull request:
   - https://github.com/huxuan/ss-python/pull/108
   - https://github.com/huxuan/ss-python/pull/111   

With slim renovate docker image, it should saves time for container initialization. With fixed version of Python and pdm, it should bring more reproducibility.