### PR TITLE
build: replace pdm-backends with setuptools and setuptools-scm

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -73,7 +73,7 @@ ARG SCM_VERSION=0.0.0
 RUN --mount=source=README.md,target=README.md \
     --mount=source=pdm.lock,target=pdm.lock \
     --mount=source=pyproject.toml,target=pyproject.toml \
-    --mount=source=src,target=src \
+    --mount=source=src,target=src,rw \
     mkdir __pypackages__ && SETUPTOOLS_SCM_PRETEND_VERSION_FOR_SS_PYTHON=${SCM_VERSION} pdm sync --prod --no-editable
 
 ########################################################################################

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -69,12 +69,12 @@ FROM dev as build
 
 # Install dependencies and project into the local packages directory.
 WORKDIR /workspace
-ARG PDM_BUILD_SCM_VERSION=0.0.0
+ARG SCM_VERSION=0.0.0
 RUN --mount=source=README.md,target=README.md \
     --mount=source=pdm.lock,target=pdm.lock \
     --mount=source=pyproject.toml,target=pyproject.toml \
     --mount=source=src,target=src \
-    mkdir __pypackages__ && PDM_BUILD_SCM_VERSION=${PDM_BUILD_SCM_VERSION} pdm sync --prod --no-editable
+    mkdir __pypackages__ && SETUPTOOLS_SCM_PRETEND_VERSION_FOR_SS_PYTHON=${SCM_VERSION} pdm sync --prod --no-editable
 
 ########################################################################################
 # Prod image is used for deployment and distribution.

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -61,6 +61,9 @@ RUN groupadd --gid $USER_GID $USERNAME \
 # Set permission for related folders
 RUN chown -R $USER_UID:$USER_GID $PIPX_HOME $PIPX_BIN_DIR
 
+# Set default working directory
+WORKDIR /workspace
+
 ########################################################################################
 # Build image is an intermediate image used for building the project.
 ########################################################################################
@@ -68,8 +71,7 @@ RUN chown -R $USER_UID:$USER_GID $PIPX_HOME $PIPX_BIN_DIR
 FROM dev as build
 
 # Install dependencies and project into the local packages directory.
-WORKDIR /workspace
-ARG SCM_VERSION=0.0.0
+ARG SCM_VERSION
 RUN --mount=source=README.md,target=README.md \
     --mount=source=pdm.lock,target=pdm.lock \
     --mount=source=pyproject.toml,target=pyproject.toml \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
             --target dev
       - run: |
           docker buildx build . \
-            --build-arg PDM_BUILD_SCM_VERSION=${{ github.ref_name }} \
+            --build-arg SCM_VERSION=${{ github.ref_name }} \
             --build-arg PYTHON_VERSION=${{ matrix.python-version }} \
             --cache-from type=registry,ref=ghcr.io/${{ github.repository }}/dev-cache:py${{ matrix.python-version }} \
             --file .devcontainer/Dockerfile \

--- a/.gitlab/workflows/release.yml
+++ b/.gitlab/workflows/release.yml
@@ -59,7 +59,7 @@ container-publish:
         --target dev
     - |
       docker buildx build . \
-        --build-arg PDM_BUILD_SCM_VERSION=${CI_COMMIT_TAG} \
+        --build-arg SCM_VERSION=${CI_COMMIT_TAG} \
         --build-arg PYTHON_VERSION=${PYTHON_VERSION} \
         --cache-from type=registry,ref=${CI_REGISTRY_IMAGE}/dev-cache:py${PYTHON_VERSION} \
         --file .devcontainer/Dockerfile \

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you find this helpful, please consider [sponsorship](https://github.com/spons
 
 - Project setup and template update with [copier](https://copier.readthedocs.io/).
 - Manage dependencies and virtual environments with [pdm](https://pdm-project.org/).
-- Build with [pdm-backend](https://backend.pdm-project.org/) and versioned with [SCM tag](https://backend.pdm-project.org/metadata/#read-from-scm-tag-supporting-git-and-hg).
+- Build with [setuptools](https://github.com/pypa/setuptools) and versioned with [setuptools-scm](https://github.com/pypa/setuptools_scm/).
 - Lint with [pre-commit](https://pre-commit.com), [mypy](http://www.mypy-lang.org/), [ruff](https://github.com/charliermarsh/ruff), [toml-sort](https://github.com/pappasam/toml-sort) and [commitlint](https://commitlint.js.org/).
 - Test with [pytest](https://pytest.org/) and [coverage](https://coverage.readthedocs.io) for threshold and reports.
 - Documentation with [sphinx](https://www.sphinx-doc.org/), the [furo](https://pradyunsg.me/furo) theme and [MyST parser](https://myst-parser.readthedocs.io/) for markdown.

--- a/includes/sample.jinja
+++ b/includes/sample.jinja
@@ -14,7 +14,7 @@ If you find this helpful, please consider [sponsorship](https://github.com/spons
 
 - Project setup and template update with [copier](https://copier.readthedocs.io/).
 - Manage dependencies and virtual environments with [pdm](https://pdm-project.org/).
-- Build with [pdm-backend](https://backend.pdm-project.org/) and versioned with [SCM tag](https://backend.pdm-project.org/metadata/#read-from-scm-tag-supporting-git-and-hg).
+- Build with [setuptools](https://github.com/pypa/setuptools) and versioned with [setuptools-scm](https://github.com/pypa/setuptools_scm/).
 - Lint with [pre-commit](https://pre-commit.com), [mypy](http://www.mypy-lang.org/), [ruff](https://github.com/charliermarsh/ruff), [toml-sort](https://github.com/pappasam/toml-sort) and [commitlint](https://commitlint.js.org/).
 - Test with [pytest](https://pytest.org/) and [coverage](https://coverage.readthedocs.io) for threshold and reports.
 - Documentation with [sphinx](https://www.sphinx-doc.org/), the [furo](https://pradyunsg.me/furo) theme and [MyST parser](https://myst-parser.readthedocs.io/) for markdown.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,9 +96,6 @@ test = [
   "pytest",
 ]
 
-[tool.pdm.version]
-source = "scm"
-
 [tool.pytest.ini_options]
 addopts = "-l -s --durations=0"
 log_cli = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 [build-system]
-build-backend = "pdm.backend"
+build-backend = "setuptools.build_meta"
 requires = [
-  "pdm-backend==2.3.0",
+  "setuptools-scm==8.1.0",
+  "setuptools==70.0.0",
 ]
 
 [project]
@@ -132,6 +133,9 @@ select = [
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
+
+[tool.setuptools_scm]
+fallback_version = "0.0.0"
 
 [tool.tomlsort]
 all = true

--- a/template/.devcontainer/Dockerfile.jinja
+++ b/template/.devcontainer/Dockerfile.jinja
@@ -69,12 +69,12 @@ FROM dev as build
 
 # Install dependencies and project into the local packages directory.
 WORKDIR /workspace
-ARG PDM_BUILD_SCM_VERSION=0.0.0
+ARG SCM_VERSION=0.0.0
 RUN --mount=source=README.md,target=README.md \
     --mount=source=pdm.lock,target=pdm.lock \
     --mount=source=pyproject.toml,target=pyproject.toml \
     --mount=source=src,target=src \
-    mkdir __pypackages__ && PDM_BUILD_SCM_VERSION=${PDM_BUILD_SCM_VERSION} pdm sync --prod --no-editable
+    mkdir __pypackages__ && SETUPTOOLS_SCM_PRETEND_VERSION_FOR_{{ package_name|upper|replace(".", "_")|replace("-", "_") }}=${SCM_VERSION} pdm sync --prod --no-editable
 
 ########################################################################################
 # Prod image is used for deployment and distribution.

--- a/template/.devcontainer/Dockerfile.jinja
+++ b/template/.devcontainer/Dockerfile.jinja
@@ -61,6 +61,9 @@ RUN groupadd --gid $USER_GID $USERNAME \
 # Set permission for related folders
 RUN chown -R $USER_UID:$USER_GID $PIPX_HOME $PIPX_BIN_DIR
 
+# Set default working directory
+WORKDIR /workspace
+
 ########################################################################################
 # Build image is an intermediate image used for building the project.
 ########################################################################################
@@ -68,8 +71,7 @@ RUN chown -R $USER_UID:$USER_GID $PIPX_HOME $PIPX_BIN_DIR
 FROM dev as build
 
 # Install dependencies and project into the local packages directory.
-WORKDIR /workspace
-ARG SCM_VERSION=0.0.0
+ARG SCM_VERSION
 RUN --mount=source=README.md,target=README.md \
     --mount=source=pdm.lock,target=pdm.lock \
     --mount=source=pyproject.toml,target=pyproject.toml \

--- a/template/.devcontainer/Dockerfile.jinja
+++ b/template/.devcontainer/Dockerfile.jinja
@@ -73,7 +73,7 @@ ARG SCM_VERSION=0.0.0
 RUN --mount=source=README.md,target=README.md \
     --mount=source=pdm.lock,target=pdm.lock \
     --mount=source=pyproject.toml,target=pyproject.toml \
-    --mount=source=src,target=src \
+    --mount=source=src,target=src,rw \
     mkdir __pypackages__ && SETUPTOOLS_SCM_PRETEND_VERSION_FOR_{{ package_name|upper|replace(".", "_")|replace("-", "_") }}=${SCM_VERSION} pdm sync --prod --no-editable
 
 ########################################################################################

--- a/template/[% if repo_platform == 'github' %].github[% endif %]/workflows/release.yml.jinja
+++ b/template/[% if repo_platform == 'github' %].github[% endif %]/workflows/release.yml.jinja
@@ -64,7 +64,7 @@ jobs:
             --target dev
       - run: |
           docker buildx build . \
-            --build-arg PDM_BUILD_SCM_VERSION={{ '${{ github.ref_name }}' }} \
+            --build-arg SCM_VERSION={{ '${{ github.ref_name }}' }} \
             --build-arg PYTHON_VERSION={{ '${{ matrix.python-version }}' }} \
             --cache-from type=registry,ref=ghcr.io/{{ '${{ github.repository }}' }}/dev-cache:py{{ '${{ matrix.python-version }}' }} \
             --file .devcontainer/Dockerfile \

--- a/template/[% if repo_platform == 'gitlab' or repo_platform == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/release.yml.jinja
+++ b/template/[% if repo_platform == 'gitlab' or repo_platform == 'gitlab-self-managed' %].gitlab[% endif %]/workflows/release.yml.jinja
@@ -70,7 +70,7 @@ container-publish:
         --target dev
     - |
       docker buildx build . \
-        --build-arg PDM_BUILD_SCM_VERSION=${CI_COMMIT_TAG} \
+        --build-arg SCM_VERSION=${CI_COMMIT_TAG} \
         --build-arg PYTHON_VERSION=${PYTHON_VERSION} \
         --cache-from type=registry,ref=${CI_REGISTRY_IMAGE}/dev-cache:py${PYTHON_VERSION} \
         --file .devcontainer/Dockerfile \

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -2,9 +2,10 @@
 [% from pathjoin("includes", "variable.jinja") import repo_url with context -%]
 [% from pathjoin("includes", "version_compare.jinja") import version_between -%]
 [build-system]
-build-backend = "pdm.backend"
+build-backend = "setuptools.build_meta"
 requires = [
-  "pdm-backend==2.3.0",
+  "setuptools-scm==8.1.0",
+  "setuptools==70.0.0",
 ]
 
 [project]
@@ -175,6 +176,9 @@ select = [
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
+
+[tool.setuptools_scm]
+fallback_version = "0.0.0"
 
 [tool.tomlsort]
 all = true

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -137,9 +137,6 @@ test = [
   "pytest",
 ]
 
-[tool.pdm.version]
-source = "scm"
-
 [tool.pytest.ini_options]
 addopts = "-l -s --durations=0"
 log_cli = true


### PR DESCRIPTION
Prefer setuptools since it supports C extension natively. I just realize that `pdm-backend` supports C extension by leverage `setuptools`. :-(

Test workflow:
- Semantic Release: https://github.com/huxuan/ss-python/actions/runs/9205816111/job/25322316985
- Package Publish (failed for publish authentication): https://github.com/huxuan/ss-python/actions/runs/9205821904/job/25322336090
- Container Publish (one of them): https://github.com/huxuan/ss-python/actions/runs/9205821904/job/25322337453 


<!-- readthedocs-preview ss-python start -->
----
📚 Documentation preview 📚: https://ss-python--580.org.readthedocs.build/en/580/

<!-- readthedocs-preview ss-python end -->