### PR TITLE
ci: run readthedocs preview on pull_request instead

### DIFF
--- a/.github/workflows/readthedocs-preview.yml
+++ b/.github/workflows/readthedocs-preview.yml
@@ -10,7 +10,7 @@ jobs:
         with:
           project-slug: ss-python
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
     paths:


### PR DESCRIPTION


<!-- readthedocs-preview ss-python start -->
----
📚 Documentation preview 📚: https://ss-python--581.org.readthedocs.build/en/581/

<!-- readthedocs-preview ss-python end -->