### PR TITLE
chore: use pipx instead of asdf for readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,4 +1,6 @@
 build:
+  apt_packages:
+    - pipx
   jobs:
     post_checkout:
       - git fetch --unshallow || true
@@ -20,9 +22,7 @@ build:
     post_system_dependencies:
       - env | sort
     pre_create_environment:
-      - asdf plugin add pdm
-      - asdf install pdm 2.16.1
-      - asdf global pdm 2.16.1
+      - PIPX_BIN_DIR=$READTHEDOCS_VIRTUALENV_PATH/bin pipx install pdm==2.16.1
     post_install:
       - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH make dev-doc
     post_build:

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -8,7 +8,7 @@
         {
             "customType": "regex",
             "datasourceTemplate": "pypi",
-            "description": "Match Python packages installed with pip, pipx and asdf",
+            "description": "Match Python packages installed with pip/pipx",
             "fileMatch": [
                 "^README\\.md$",
                 "^\\.devcontainer/Dockerfile$",
@@ -26,8 +26,6 @@
                 "^template/docs/.+\\.md(\\.jinja)?$"
             ],
             "matchStrings": [
-                "asdf global (?<depName>.*?) (?<currentValue>.*?)\n",
-                "asdf install (?<depName>.*?) (?<currentValue>.*?)\n",
                 "pip install.* (?<depName>.*?)==(?<currentValue>.*?)[\"\n]",
                 "pipx install (?<depName>.*?)==(?<currentValue>.*?)[;\n]"
             ]

--- a/docs/management/update.md
+++ b/docs/management/update.md
@@ -26,7 +26,7 @@ The project template tracks the following dependencies:
    1. [gitlabci](https://docs.renovatebot.com/modules/manager/gitlabci/): Containers in GitLab CI/CD.
    1. [pre-commit](https://docs.renovatebot.com/modules/manager/pre-commit/): Pre-commit hooks.
 1. Regex manager:
-   1. Python packages installed with pip, pipx and asdf, listed in the README, DevContainer Dockerfile, GitHub Actions, GitLab CI/CD, ReadTheDocs configuration, Renovate configuration and documentation.
+   1. Python packages installed with pip/pipx, listed in the README, DevContainer Dockerfile, GitHub Actions, GitLab CI/CD, ReadTheDocs configuration, Renovate configuration and documentation.
    1. Debian packages installed in the DevContainer Dockerfile.
    1. PDM version specified in the `pdm-project/setup-pdm` GitHub action.
    1. PDM version specified in the renovate constraints.

--- a/template/.readthedocs.yaml.jinja
+++ b/template/.readthedocs.yaml.jinja
@@ -1,4 +1,6 @@
 build:
+  apt_packages:
+    - pipx
   jobs:
     post_checkout:
       - git fetch --unshallow || true
@@ -20,9 +22,7 @@ build:
     post_system_dependencies:
       - env | sort
     pre_create_environment:
-      - asdf plugin add pdm
-      - asdf install pdm 2.16.1
-      - asdf global pdm 2.16.1
+      - PIPX_BIN_DIR=$READTHEDOCS_VIRTUALENV_PATH/bin pipx install pdm==2.16.1
     post_install:
       - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH make dev-doc
     post_build:

--- a/template/.renovaterc.json.jinja
+++ b/template/.renovaterc.json.jinja
@@ -9,7 +9,7 @@
         {
             "customType": "regex",
             "datasourceTemplate": "pypi",
-            "description": "Match Python packages installed with pip, pipx and asdf",
+            "description": "Match Python packages installed with pip/pipx",
             "fileMatch": [
                 "^README\\.md$",
                 "^\\.devcontainer/Dockerfile$",
@@ -29,8 +29,6 @@
 [%- endif %]
             ],
             "matchStrings": [
-                "asdf global (?<depName>.*?) (?<currentValue>.*?)\n",
-                "asdf install (?<depName>.*?) (?<currentValue>.*?)\n",
                 "pip install.* (?<depName>.*?)==(?<currentValue>.*?)[\"\n]",
                 "pipx install (?<depName>.*?)==(?<currentValue>.*?)[;\n]"
             ]

--- a/template/docs/management/update.md
+++ b/template/docs/management/update.md
@@ -26,7 +26,7 @@ The project template tracks the following dependencies:
    1. [gitlabci](https://docs.renovatebot.com/modules/manager/gitlabci/): Containers in GitLab CI/CD.
    1. [pre-commit](https://docs.renovatebot.com/modules/manager/pre-commit/): Pre-commit hooks.
 1. Regex manager:
-   1. Python packages installed with pip, pipx and asdf, listed in the README, DevContainer Dockerfile, GitHub Actions, GitLab CI/CD, ReadTheDocs configuration, Renovate configuration and documentation.
+   1. Python packages installed with pip/pipx, listed in the README, DevContainer Dockerfile, GitHub Actions, GitLab CI/CD, ReadTheDocs configuration, Renovate configuration and documentation.
    1. Debian packages installed in the DevContainer Dockerfile.
    1. PDM version specified in the `pdm-project/setup-pdm` GitHub action.
    1. PDM version specified in the renovate constraints.


### PR DESCRIPTION


<!-- readthedocs-preview ss-python start -->
----
📚 Documentation preview 📚: https://ss-python--622.org.readthedocs.build/en/622/

<!-- readthedocs-preview ss-python end -->