### PR TITLE
docs: fix git clone url

### DIFF
--- a/docs/management/init.md
+++ b/docs/management/init.md
@@ -17,7 +17,7 @@ pipx install copier==9.2.0
 Create a blank Git repository on the hosting platform. Clone it locally and navigate to the root directory:
 
 ```bash
-git clone git@github.com/serious-scaffold/ss-python.git
+git clone git@github.com:serious-scaffold/ss-python.git
 cd ss-python
 ```
 

--- a/template/docs/management/init.md.jinja
+++ b/template/docs/management/init.md.jinja
@@ -18,7 +18,7 @@ pipx install copier==9.2.0
 Create a blank Git repository on the hosting platform. Clone it locally and navigate to the root directory:
 
 ```bash
-git clone git@{{ repo_url() }}.git
+git clone git@{{ repo_host }}:{{ repo_namespace }}/{{ repo_name }}.git
 cd {{ repo_name }}
 ```
 


### PR DESCRIPTION


<!-- readthedocs-preview ss-python start -->
----
📚 Documentation preview 📚: https://ss-python--629.org.readthedocs.build/en/629/

<!-- readthedocs-preview ss-python end -->