### PR TITLE
refactor: refine Makefile

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -26,7 +26,7 @@ build:
     post_install:
       - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH make dev-doc
     post_build:
-      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH make doc-mypy doc-coverage
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH make mypy doc-coverage
   os: ubuntu-22.04
   tools:
     python: '3.12'

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean deepclean install dev prerequisites mypy ruff ruff-format pyproject-fmt codespell lint pre-commit test-run test build publish doc-autobuild doc-gen doc-mypy doc-coverage doc consistency
+.PHONY: clean deepclean install dev prerequisites mypy ruff ruff-format pyproject-fmt codespell lint pre-commit test-run test build publish doc-autobuild doc-build doc-coverage doc consistency
 
 ########################################################################################
 # Variables
@@ -42,16 +42,16 @@ deepclean: clean
 
 # Install the package in editable mode.
 install:
-	pdm install --prod
+	pdm sync --prod
 
 # Install the package in editable mode with specific optional dependencies.
 dev-%:
-	pdm install --dev --group $*
+	pdm sync --dev --group $*
 
 # Prepare the development environment.
 # Install the package in editable mode with all optional dependencies and pre-commit hook.
 dev:
-	pdm install
+	pdm sync
 	if [ "$(CI)" != "true" ] && command -v pre-commit > /dev/null 2>&1; then pre-commit install; fi
 
 # Install standalone tools
@@ -72,7 +72,7 @@ endif
 
 # Check lint with mypy.
 mypy:
-	pdm run python -m mypy .
+	pdm run python -m mypy . --html-report $(PUBLIC_DIR)/reports/mypy
 
 # Lint with ruff.
 ruff:
@@ -135,12 +135,8 @@ doc-autobuild:
 		-a
 
 # Build documentation only from src.
-doc-gen:
+doc-build:
 	pdm run python -m sphinx.cmd.build docs $(PUBLIC_DIR)
-
-# Generate mypy reports.
-doc-mypy:
-	pdm run python -m mypy src tests --html-report $(PUBLIC_DIR)/reports/mypy
 
 # Generate html coverage reports with badge.
 doc-coverage: test-run
@@ -148,7 +144,7 @@ doc-coverage: test-run
 	pdm run bash scripts/generate-coverage-badge.sh $(PUBLIC_DIR)/_static/badges
 
 # Generate all documentation with reports.
-doc: doc-gen doc-mypy doc-coverage
+doc: doc-build mypy doc-coverage
 
 ########################################################################################
 # Template

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,7 @@ enable_error_code = [
 ]
 exclude = [
     "build",
+    "doc",
     "template",
 ]
 no_implicit_optional = true

--- a/template/.readthedocs.yaml.jinja
+++ b/template/.readthedocs.yaml.jinja
@@ -26,7 +26,7 @@ build:
     post_install:
       - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH make dev-doc
     post_build:
-      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH make doc-mypy doc-coverage
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH make mypy doc-coverage
   os: ubuntu-22.04
   tools:
     python: '{{ default_py }}'

--- a/template/Makefile.jinja
+++ b/template/Makefile.jinja
@@ -1,5 +1,5 @@
 [% from pathjoin("includes", "variable.jinja") import page_url with context -%]
-.PHONY: clean deepclean install dev prerequisites mypy ruff ruff-format pyproject-fmt codespell lint pre-commit test-run test build publish doc-autobuild doc-gen doc-mypy doc-coverage doc
+.PHONY: clean deepclean install dev prerequisites mypy ruff ruff-format pyproject-fmt codespell lint pre-commit test-run test build publish doc-autobuild doc-build doc-coverage doc
 [%- if project_name == "Serious Scaffold Python" %] consistency[% endif %]
 
 ########################################################################################
@@ -44,16 +44,16 @@ deepclean: clean
 
 # Install the package in editable mode.
 install:
-	pdm install --prod
+	pdm sync --prod
 
 # Install the package in editable mode with specific optional dependencies.
 dev-%:
-	pdm install --dev --group $*
+	pdm sync --dev --group $*
 
 # Prepare the development environment.
 # Install the package in editable mode with all optional dependencies and pre-commit hook.
 dev:
-	pdm install
+	pdm sync
 	if [ "$(CI)" != "true" ] && command -v pre-commit > /dev/null 2>&1; then pre-commit install; fi
 
 # Install standalone tools
@@ -74,7 +74,7 @@ endif
 
 # Check lint with mypy.
 mypy:
-	pdm run python -m mypy .
+	pdm run python -m mypy . --html-report $(PUBLIC_DIR)/reports/mypy
 
 # Lint with ruff.
 ruff:
@@ -137,12 +137,8 @@ doc-autobuild:
 		-a
 
 # Build documentation only from src.
-doc-gen:
+doc-build:
 	pdm run python -m sphinx.cmd.build docs $(PUBLIC_DIR)
-
-# Generate mypy reports.
-doc-mypy:
-	pdm run python -m mypy src tests --html-report $(PUBLIC_DIR)/reports/mypy
 
 # Generate html coverage reports with badge.
 doc-coverage: test-run
@@ -150,7 +146,7 @@ doc-coverage: test-run
 	pdm run bash scripts/generate-coverage-badge.sh $(PUBLIC_DIR)/_static/badges
 
 # Generate all documentation with reports.
-doc: doc-gen doc-mypy doc-coverage
+doc: doc-build mypy doc-coverage
 
 [% if project_name == "Serious Scaffold Python" -%]
 ########################################################################################

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -170,6 +170,7 @@ enable_error_code = [
 ]
 exclude = [
     "build",
+    "doc",
 [%- if project_name == "Serious Scaffold Python" %]
     "template",
 [%- endif %]


### PR DESCRIPTION
1. Use `pdm sync` instead of `pdm install` for speed up: https://pdm-project.org/latest/usage/lockfile/#install-the-packages-pinned-in-lock-file
2. Avoid run `mypy` twice in CI.
3. Slightly unify name `doc-build` v.s. `doc-autobuild`.

<!-- readthedocs-preview ss-python start -->
----
📚 Documentation preview 📚: https://ss-python--639.org.readthedocs.build/en/639/

<!-- readthedocs-preview ss-python end -->