### PR TITLE
fix: fix renovate regex match for pip/pipx

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -28,8 +28,8 @@
                 "^template/docs/.+\\.md(\\.jinja)?$"
             ],
             "matchStrings": [
-                "pip install.* (?<depName>.*?)==(?<currentValue>.*?)[\"\n]",
-                "pipx install( --force)? (?<depName>.*?)==(?<currentValue>.*?)\n"
+                "pip install.* (?<depName>.*?)(\\[.*?\\])?==(?<currentValue>.*?)[\"\n]",
+                "pipx install( --force)? (?<depName>.*?)(\\[.*?\\])?==(?<currentValue>.*?)\\s"
             ]
         },
         {

--- a/template/.renovaterc.json.jinja
+++ b/template/.renovaterc.json.jinja
@@ -31,8 +31,8 @@
 [%- endif %]
             ],
             "matchStrings": [
-                "pip install.* (?<depName>.*?)==(?<currentValue>.*?)[\"\n]",
-                "pipx install( --force)? (?<depName>.*?)==(?<currentValue>.*?)\n"
+                "pip install.* (?<depName>.*?)(\\[.*?\\])?==(?<currentValue>.*?)[\"\n]",
+                "pipx install( --force)? (?<depName>.*?)(\\[.*?\\])?==(?<currentValue>.*?)\\s"
             ]
         },
         {


### PR DESCRIPTION
Run log: https://github.com/huxuan/ss-python/actions/runs/9856250054/job/27212842078
New parsed result: (Captured from https://github.com/huxuan/ss-python/issues/63)

![image](https://github.com/serious-scaffold/ss-python/assets/726061/8126c9f2-37b0-4b45-9b91-0a1d382b3ca0)

T current parsed result: (Captured from https://github.com/serious-scaffold/ss-python/issues/331)

![image](https://github.com/serious-scaffold/ss-python/assets/726061/0af6b03c-ab7a-43f6-b7e2-2663222845f4)
