### PR TITLE
fix: no Optional when min_py is not higher than 3.10

### DIFF
--- a/template/src/{{ module_name }}/settings.py.jinja
+++ b/template/src/{{ module_name }}/settings.py.jinja
@@ -20,7 +20,11 @@ class GlobalSettings(BaseSettings):
 class Settings(BaseSettings):
     """Project specific settings."""
 
+    [%- if not version_higher_than(min_py, "3.10") %]
     logging_level: Optional[str] = getLevelName(logging.INFO)
+    [%- else %]
+    logging_level: str | None = getLevelName(logging.INFO)
+    [%- endif %]
     """Default logging level for the project."""
 
     model_config = SettingsConfigDict(


### PR DESCRIPTION
fix: if min_py not higher than 3.10,  Optional will not be import, error with Optional[str] 
question:
<img width="634" alt="image" src="https://github.com/user-attachments/assets/71601389-42ac-476f-a65c-86d2b1bab729">

test result:
1.
<img width="279" alt="image" src="https://github.com/user-attachments/assets/e5ffa6cc-213b-4b49-a173-478b11087357">
<img width="588" alt="image" src="https://github.com/user-attachments/assets/ae21bc54-219e-4bbd-bfe9-94bab3c7f53c">

2.
<img width="566" alt="image" src="https://github.com/user-attachments/assets/2fd81c0d-0961-4fbc-b4be-3a4ac6f45754">


