### PR TITLE
fix: no Optional when min_py is not higher than 3.10

### DIFF
--- a/template/src/{{ module_name }}/settings.py.jinja
+++ b/template/src/{{ module_name }}/settings.py.jinja
@@ -21,8 +21,11 @@ class Settings(BaseSettings):
     """Project specific settings."""
 
     [%- if not version_higher_than(min_py, "3.10") %]
+
     logging_level: Optional[str] = getLevelName(logging.INFO)
+
     [%- else %]
+
     logging_level: str | None = getLevelName(logging.INFO)
     [%- endif %]
     """Default logging level for the project."""

--- a/template/src/{{ module_name }}/settings.py.jinja
+++ b/template/src/{{ module_name }}/settings.py.jinja
@@ -20,7 +20,11 @@ class GlobalSettings(BaseSettings):
 class Settings(BaseSettings):
     """Project specific settings."""
 
+    [%- if not version_higher_than(min_py, "3.10") %]
     logging_level: Optional[str] = getLevelName(logging.INFO)
+    [%- else %]
+    logging_level: str | None = getLevelName(logging.INFO)
+    [%- endif %]
     """Default logging level for the project."""
 
     model_config = SettingsConfigDict(


### PR DESCRIPTION
question:
<img width="654" alt="image" src="https://github.com/user-attachments/assets/decb83c4-7b61-4374-a0ff-dfd0a6cc1e53">

test result:
1.
<img width="448" alt="image" src="https://github.com/user-attachments/assets/9b50e33a-085e-4a0e-9cb4-0578487f6c58">
2.
<img width="427" alt="image" src="https://github.com/user-attachments/assets/cca36e76-3f3c-4104-8bf2-d3dc3a784640">
3. make template-build & git diff
<img width="93" alt="image" src="https://github.com/user-attachments/assets/53864597-2ff1-4cb1-9421-b1aaaee51f83">

