### PR TITLE
fix: make dev failed when lockfile does not exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,16 +42,16 @@ deepclean: clean
 
 # Install the package in editable mode.
 install:
-	pdm sync --prod
+	pdm install --prod
 
 # Install the package in editable mode with specific optional dependencies.
 dev-%: install
-	pdm sync --lockfile pdm.dev.lock --no-default --dev --group $*
+	pdm install --lockfile pdm.dev.lock --no-default --dev --group $*
 
 # Prepare the development environment.
 # Install the package in editable mode with all optional dependencies and pre-commit hook.
 dev: install
-	pdm sync --lockfile pdm.dev.lock
+	pdm install --lockfile pdm.dev.lock
 	if [ "$(CI)" != "true" ] && command -v pre-commit > /dev/null 2>&1; then pre-commit install; fi
 
 # Install standalone tools

--- a/template/Makefile.jinja
+++ b/template/Makefile.jinja
@@ -44,16 +44,16 @@ deepclean: clean
 
 # Install the package in editable mode.
 install:
-	pdm sync --prod
+	pdm install --prod
 
 # Install the package in editable mode with specific optional dependencies.
 dev-%: install
-	pdm sync --lockfile pdm.dev.lock --no-default --dev --group $*
+	pdm install --lockfile pdm.dev.lock --no-default --dev --group $*
 
 # Prepare the development environment.
 # Install the package in editable mode with all optional dependencies and pre-commit hook.
 dev: install
-	pdm sync --lockfile pdm.dev.lock
+	pdm install --lockfile pdm.dev.lock
 	if [ "$(CI)" != "true" ] && command -v pre-commit > /dev/null 2>&1; then pre-commit install; fi
 
 # Install standalone tools


### PR DESCRIPTION
question:
<img width="559" alt="image" src="https://github.com/user-attachments/assets/bd0bc5d7-46ec-4d75-b8c0-684fcaba5366">

test result:
<img width="647" alt="image" src="https://github.com/user-attachments/assets/1e4165a8-71a9-4d51-a3cb-f5b1fd75564b">

make template-build && git diff:
<img width="112" alt="image" src="https://github.com/user-attachments/assets/899147d6-9a09-4f2d-ad08-1030e6320b02">


<!-- readthedocs-preview ss-python start -->
----
📚 Documentation preview 📚: https://ss-python--805.org.readthedocs.build/en/805/

<!-- readthedocs-preview ss-python end -->