### PR TITLE
fix:  from [tool.pdm.dev-dependencies] to [dependency-groups]

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -82,10 +82,7 @@ urls.issue = "https://{{ repo_url() }}/-/issues"
 urls.repository = "https://{{ repo_url() }}"
 scripts.{{ package_name }}-cli = "{{ module_name }}.cli:cli"
 
-[tool.pdm]
-distribution = true
-
-[tool.pdm.dev-dependencies]
+[dependency-groups]
 doc = [
     "Sphinx",
     "autodoc-pydantic",
@@ -104,6 +101,9 @@ test = [
     "coverage",
     "pytest",
 ]
+
+[tool.pdm]
+distribution = true
 
 [tool.setuptools_scm]
 fallback_version = "0.0.0"


### PR DESCRIPTION
I'm not sure this change is reasonable.

But I found [tool.pdm.dev-dependencies] does not work well with a command like `pdm add -d ipdb` (pdm does not install pip by default, so I chose this way to install ipdb).

`pdm add -d ipdb` will create a new section [dependency-groups], which is a combination of [tool.pdm.dev-dependencies] + 
`dev = ["ipdb>=0.13.13"]` within it.

# Extra Info
PDM, version 2.21.0


Thanks.