### PR TITLE
feat(no-release): use dependency-groups according to pep735

### DIFF
--- a/pdm.dev.lock
+++ b/pdm.dev.lock
@@ -5,7 +5,7 @@
 groups = ["doc", "lint", "test"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:9d1991579e577ae201fbefcdc354ace2f16921ef6049d56d06685538be70c2ba"
+content_hash = "sha256:bb122c24e17decd9d1d6c8b6bf2bad444717e0ca671e262ed2ddde2be4851df2"
 
 [[metadata.targets]]
 requires_python = ">=3.9"

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:9d1991579e577ae201fbefcdc354ace2f16921ef6049d56d06685538be70c2ba"
+content_hash = "sha256:bb122c24e17decd9d1d6c8b6bf2bad444717e0ca671e262ed2ddde2be4851df2"
 
 [[metadata.targets]]
 requires_python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,28 +43,28 @@ urls.issue = "https://github.com/serious-scaffold/ss-python/issues"
 urls.repository = "https://github.com/serious-scaffold/ss-python"
 scripts.ss-python-cli = "ss_python.cli:cli"
 
-[tool.pdm]
-distribution = true
-
-[tool.pdm.dev-dependencies]
+[dependency-groups]
+test = [
+    "coverage",
+    "pytest",
+]
 doc = [
-    "Sphinx",
     "autodoc-pydantic",
     "coverage",
     "furo",
     "mypy[reports]",
     "myst-parser",
     "pytest",
+    "sphinx",
     "sphinx-click",
     "sphinx-design",
 ]
 lint = [
     "mypy",
 ]
-test = [
-    "coverage",
-    "pytest",
-]
+
+[tool.pdm]
+distribution = true
 
 [tool.setuptools_scm]
 fallback_version = "0.0.0"

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -82,28 +82,28 @@ urls.issue = "https://{{ repo_url() }}/-/issues"
 urls.repository = "https://{{ repo_url() }}"
 scripts.{{ package_name }}-cli = "{{ module_name }}.cli:cli"
 
-[tool.pdm]
-distribution = true
-
-[tool.pdm.dev-dependencies]
+[dependency-groups]
+test = [
+    "coverage",
+    "pytest",
+]
 doc = [
-    "Sphinx",
     "autodoc-pydantic",
     "coverage",
     "furo",
     "mypy[reports]",
     "myst-parser",
     "pytest",
+    "sphinx",
     "sphinx-click",
     "sphinx-design",
 ]
 lint = [
     "mypy",
 ]
-test = [
-    "coverage",
-    "pytest",
-]
+
+[tool.pdm]
+distribution = true
 
 [tool.setuptools_scm]
 fallback_version = "0.0.0"


### PR DESCRIPTION


<!-- readthedocs-preview ss-python start -->
----
📚 Documentation preview 📚: https://ss-python--884.org.readthedocs.build/en/884/

<!-- readthedocs-preview ss-python end -->